### PR TITLE
UTF-8 issues

### DIFF
--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -910,36 +910,35 @@ rb_node_set_fence_info(VALUE self, VALUE info)
 static VALUE
 rb_html_escape_href(VALUE self, VALUE rb_text)
 {
-	char *text, *result;
-	int len;
+	VALUE result;
 	cmark_strbuf buf = GH_BUF_INIT;
+
 	Check_Type(rb_text, T_STRING);
 
-	text = (char *)RSTRING_PTR(rb_text);
-	len = RSTRING_LEN(rb_text);
+	if (houdini_escape_href(&buf, (const uint8_t *)RSTRING_PTR(rb_text), RSTRING_LEN(rb_text))) {
+		result = (char *)cmark_strbuf_detach(&buf);
+		return rb_str_new2(result);
+	}
 
-	houdini_escape_href(&buf, text, len);
-	result = (char *)cmark_strbuf_detach(&buf);
+	return rb_text;
 
-	return rb_str_new2(result);
 }
 
 /* Internal: Escapes HTML content safely. */
 static VALUE
 rb_html_escape_html(VALUE self, VALUE rb_text)
 {
-	char *text, *result;
-	int len;
+	VALUE result;
 	cmark_strbuf buf = GH_BUF_INIT;
+
 	Check_Type(rb_text, T_STRING);
 
-	text = (char *)RSTRING_PTR(rb_text);
-	len = RSTRING_LEN(rb_text);
+	if (houdini_escape_html0(&buf, (const uint8_t *)RSTRING_PTR(rb_text), RSTRING_LEN(rb_text), 0)) {
+		result = (char *)cmark_strbuf_detach(&buf);
+		return rb_str_new2(result);
+	}
 
-	houdini_escape_html0(&buf, text, len, 0);
-	result = (char *)cmark_strbuf_detach(&buf);
-
-	return rb_str_new2(result);
+	return rb_text;
 }
 
 __attribute__((visibility("default")))

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -74,6 +74,8 @@ rb_node_to_value(cmark_node *node)
 {
 	void *user_data;
 	RUBY_DATA_FUNC free_func;
+	VALUE val;
+
 	if (node == NULL)
 		return Qnil;
 
@@ -83,10 +85,10 @@ rb_node_to_value(cmark_node *node)
 
 	/* Only free tree roots. */
 	free_func = cmark_node_parent(node)
-	                           ? NULL
-	                           : rb_free_c_struct;
-	VALUE val = Data_Wrap_Struct(rb_mNode, rb_mark_c_struct, free_func,
-	                             node);
+	            ? NULL
+	            : rb_free_c_struct;
+	val = Data_Wrap_Struct(rb_mNode, rb_mark_c_struct, free_func,
+	                       node);
 	cmark_node_set_user_data(node, (void *)val);
 
 	return val;
@@ -270,6 +272,8 @@ rb_node_set_string_content(VALUE self, VALUE s)
 	if (!cmark_node_set_literal(node, text)) {
 		rb_raise(rb_mNodeError, "could not set string content");
 	}
+
+	return Qnil;
 }
 
 /*
@@ -944,6 +948,7 @@ rb_html_escape_html(VALUE self, VALUE rb_text)
 __attribute__((visibility("default")))
 void Init_commonmarker()
 {
+	VALUE module;
 	sym_document    = ID2SYM(rb_intern("document"));
 	sym_blockquote  = ID2SYM(rb_intern("blockquote"));
 	sym_list      	= ID2SYM(rb_intern("list"));
@@ -966,7 +971,7 @@ void Init_commonmarker()
 	sym_bullet_list  = ID2SYM(rb_intern("bullet_list"));
 	sym_ordered_list = ID2SYM(rb_intern("ordered_list"));
 
-	VALUE module = rb_define_module("CommonMarker");
+	module = rb_define_module("CommonMarker");
 	rb_mNodeError = rb_define_class_under(module, "NodeError", rb_eStandardError);
 	rb_mNode = rb_define_class_under(module, "Node", rb_cObject);
 	rb_define_singleton_method(rb_mNode, "markdown_to_html", rb_markdown_to_html, 2);

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -914,7 +914,7 @@ rb_node_set_fence_info(VALUE self, VALUE info)
 static VALUE
 rb_html_escape_href(VALUE self, VALUE rb_text)
 {
-	VALUE result;
+	char *result;
 	cmark_strbuf buf = GH_BUF_INIT;
 
 	Check_Type(rb_text, T_STRING);
@@ -932,7 +932,7 @@ rb_html_escape_href(VALUE self, VALUE rb_text)
 static VALUE
 rb_html_escape_html(VALUE self, VALUE rb_text)
 {
-	VALUE result;
+	char *result;
 	cmark_strbuf buf = GH_BUF_INIT;
 
 	Check_Type(rb_text, T_STRING);

--- a/lib/commonmarker.rb
+++ b/lib/commonmarker.rb
@@ -18,7 +18,7 @@ module CommonMarker
   # Returns a {String} of converted HTML.
   def self.render_html(text, option = :default)
     fail TypeError, 'text must be a string!' unless text.is_a?(String)
-    Node.markdown_to_html(text, Config.process_options(option))
+    Node.markdown_to_html(text.encode('UTF-8'), Config.process_options(option)).force_encoding('UTF-8')
   end
 
   # Public: Parses a Markdown string into a `document` node.
@@ -29,6 +29,7 @@ module CommonMarker
   # Returns the `document` node.
   def self.render_doc(text, option = :default)
     fail TypeError, 'text must be a string!' unless text.is_a?(String)
+    text = text.encode('UTF-8')
     Node.parse_document(text, text.bytesize, Config.process_options(option))
   end
 

--- a/test/fixtures/curly.md
+++ b/test/fixtures/curly.md
@@ -1,0 +1,1 @@
+This curly quote “makes commonmarker throw an exception”.

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class TestEncoding < Minitest::Test
+  def test_encoding
+    contents = File.read(File.join(FIXTURES_DIR, 'curly.md'))
+    render = CommonMarker.render_html(contents, :smart)
+    assert_equal render.rstrip, "<p>This curly quote \\xE2\\x80\\x9Cmakes commonmarker throw an exception\\xE2\\x80\\x9D.</p>"
+  end
+end

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -1,9 +1,10 @@
 require 'test_helper'
 
 class TestEncoding < Minitest::Test
+  # see http://git.io/vq4FR
   def test_encoding
     contents = File.read(File.join(FIXTURES_DIR, 'curly.md'))
     render = CommonMarker.render_html(contents, :smart)
-    assert_equal render.rstrip, "<p>This curly quote \\xE2\\x80\\x9Cmakes commonmarker throw an exception\\xE2\\x80\\x9D.</p>"
+    assert_equal render.rstrip, '<p>This curly quote “makes commonmarker throw an exception”.</p>'
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ require 'minitest/pride'
 
 include CommonMarker
 
+FIXTURES_DIR = File.join(File.dirname(__FILE__), 'fixtures')
+
 def open_spec_file(filename, options = {})
   line_number = 0
   start_line = 0


### PR DESCRIPTION
Resolves https://github.com/gjtorikian/commonmarker/issues/9.

This might partly be a result of [Houdini's needs](https://github.com/vmg/houdini/tree/59727b85553b70d468743076219e620d6c0d3cad#houdini---the-escapist):

> Houdini parses only UTF-8 strings, and generates only UTF-8 strings. If you are using another encoding, you should probably transcode before passing the buffer to Houdini.