### PR TITLE
Make `Node` an `Enumerable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require 'commonmarker'
 doc = CommonMarker.render_doc('*Hello* world', :default)
 puts(doc.to_html) # <p>Hi <em>there</em></p>\n
 
-doc.walk do |node|
+doc.each do |node|
   puts node.type # [:document, :paragraph, :text, :emph, :text]
 end
 ```
@@ -59,16 +59,16 @@ require 'commonmarker'
 doc = CommonMarker.render_doc("# The site\n\n [GitHub](https://www.github.com)")
 
 # Walk tree and print out URLs for links
-doc.walk do |node|
+doc.each do |node|
   if node.type == :link
     printf("URL = %s\n", node.url)
   end
 end
 
 # Capitalize all regular text in headers
-doc.walk do |node|
+doc.each do |node|
   if node.type == :header
-    node.walk do |subnode|
+    node.each do |subnode|
       if subnode.type == :text
         subnode.string_content = subnode.string_content.upcase
       end
@@ -77,7 +77,7 @@ doc.walk do |node|
 end
 
 # Transform links to regular text
-doc.walk do |node|
+doc.each do |node|
   if node.type == :link
     node.insert_before(node.first_child)
     node.delete

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require 'commonmarker'
 doc = CommonMarker.render_doc('*Hello* world', :default)
 puts(doc.to_html) # <p>Hi <em>there</em></p>\n
 
-doc.each do |node|
+doc.walk do |node|
   puts node.type # [:document, :paragraph, :text, :emph, :text]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ The second argument is optional--[see below](#options) for more information.
 
 #### Example: walking the AST
 
+You can use `walk` or `each` to iterate over nodes:
+
+- `walk` will iterate on a node and recursively iterate on a node's children.
+- `each` will iterate on a node and its children, but no further.
+
 ``` ruby
 require 'commonmarker'
 
@@ -59,14 +64,14 @@ require 'commonmarker'
 doc = CommonMarker.render_doc("# The site\n\n [GitHub](https://www.github.com)")
 
 # Walk tree and print out URLs for links
-doc.each do |node|
+doc.walk do |node|
   if node.type == :link
     printf("URL = %s\n", node.url)
   end
 end
 
 # Capitalize all regular text in headers
-doc.each do |node|
+doc.walk do |node|
   if node.type == :header
     node.each do |subnode|
       if subnode.type == :text
@@ -77,7 +82,7 @@ doc.each do |node|
 end
 
 # Transform links to regular text
-doc.each do |node|
+doc.walk do |node|
   if node.type == :link
     node.insert_before(node.first_child)
     node.delete

--- a/lib/commonmarker.rb
+++ b/lib/commonmarker.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'commonmarker/commonmarker'
 require 'commonmarker/config'
+require 'commonmarker/node'
 require 'commonmarker/renderer'
 require 'commonmarker/renderer/html_renderer'
 require 'commonmarker/version'
@@ -35,39 +36,5 @@ module CommonMarker
     opts = Config.process_options(options, :parse)
     text = text.encode('UTF-8')
     Node.parse_document(text, text.bytesize, opts)
-  end
-
-  class Node
-    include Enumerable
-
-    # Public: An iterator that "walks the tree," descending into children recursively.
-    #
-    # blk - A {Proc} representing the action to take for each child
-    def each(&blk)
-      yield self
-      each_child do |child|
-        child.each(&blk)
-      end
-    end
-
-    # Public: Convert the node to an HTML string.
-    #
-    # options - A {Symbol} or {Array of Symbol}s indicating the render options
-    #
-    # Returns a {String}.
-    def to_html(options = :default)
-      opts = Config.process_options(options, :render)
-      _render_html(opts).force_encoding('utf-8')
-    end
-
-    # Internal: Iterate over the children (if any) of the current pointer.
-    def each_child
-      child = first_child
-      while child
-        nextchild = child.next
-        yield child
-        child = nextchild
-      end
-    end
   end
 end

--- a/lib/commonmarker.rb
+++ b/lib/commonmarker.rb
@@ -38,13 +38,15 @@ module CommonMarker
   end
 
   class Node
+    include Enumerable
+
     # Public: An iterator that "walks the tree," descending into children recursively.
     #
     # blk - A {Proc} representing the action to take for each child
-    def walk(&blk)
+    def each(&blk)
       yield self
       each_child do |child|
-        child.walk(&blk)
+        child.each(&blk)
       end
     end
 

--- a/lib/commonmarker/node.rb
+++ b/lib/commonmarker/node.rb
@@ -1,0 +1,35 @@
+module CommonMarker
+  class Node
+    include Enumerable
+
+    # Public: An iterator that "walks the tree," descending into children recursively.
+    #
+    # blk - A {Proc} representing the action to take for each child
+    def each(&blk)
+      yield self
+      each_child do |child|
+        child.each(&blk)
+      end
+    end
+
+    # Public: Convert the node to an HTML string.
+    #
+    # options - A {Symbol} or {Array of Symbol}s indicating the render options
+    #
+    # Returns a {String}.
+    def to_html(options = :default)
+      opts = Config.process_options(options, :render)
+      _render_html(opts).force_encoding('utf-8')
+    end
+
+    # Internal: Iterate over the children (if any) of the current pointer.
+    def each_child
+      child = first_child
+      while child
+        nextchild = child.next
+        yield child
+        child = nextchild
+      end
+    end
+  end
+end

--- a/lib/commonmarker/node.rb
+++ b/lib/commonmarker/node.rb
@@ -22,7 +22,7 @@ module CommonMarker
       _render_html(opts).force_encoding('utf-8')
     end
 
-    # Internal: Iterate over the children (if any) of the current pointer.
+    # Public: Iterate over the children (if any) of the current pointer.
     def each
       return enum_for(:each) unless block_given?
 

--- a/lib/commonmarker/node.rb
+++ b/lib/commonmarker/node.rb
@@ -5,10 +5,10 @@ module CommonMarker
     # Public: An iterator that "walks the tree," descending into children recursively.
     #
     # blk - A {Proc} representing the action to take for each child
-    def each(&blk)
+    def walk(&block)
       yield self
-      each_child do |child|
-        child.each(&blk)
+      each do |child|
+        child.walk(&block)
       end
     end
 
@@ -23,13 +23,21 @@ module CommonMarker
     end
 
     # Internal: Iterate over the children (if any) of the current pointer.
-    def each_child
+    def each
+      return enum_for(:each) unless block_given?
+
       child = first_child
       while child
         nextchild = child.next
         yield child
         child = nextchild
       end
+    end
+
+    # Deprecated: Please use `each` instead
+    def each_child(&block)
+      warn '[DEPRECATION] `each_child` is deprecated.  Please use `each` instead.'
+      each(&block)
     end
   end
 end

--- a/lib/commonmarker/node.rb
+++ b/lib/commonmarker/node.rb
@@ -6,6 +6,8 @@ module CommonMarker
     #
     # blk - A {Proc} representing the action to take for each child
     def walk(&block)
+      return enum_for(:walk) unless block_given?
+
       yield self
       each do |child|
         child.walk(&block)
@@ -23,7 +25,7 @@ module CommonMarker
     end
 
     # Public: Iterate over the children (if any) of the current pointer.
-    def each
+    def each(&block)
       return enum_for(:each) unless block_given?
 
       child = first_child

--- a/lib/commonmarker/renderer.rb
+++ b/lib/commonmarker/renderer.rb
@@ -16,7 +16,7 @@ module CommonMarker
     def out(*args)
       args.each do |arg|
         if arg == :children
-          @node.each_child { |child| out(child) }
+          @node.each { |child| out(child) }
         elsif arg.is_a?(Array)
           arg.each { |x| render(x) }
         elsif arg.is_a?(Node)
@@ -34,7 +34,7 @@ module CommonMarker
         document(node)
         return @stream.string
       elsif @in_plain && node.type != :text && node.type != :softbreak
-        node.each_child { |child| render(child) }
+        node.each { |child| render(child) }
       else
         begin
           send(node.type, node)

--- a/test/test_attributes.rb
+++ b/test/test_attributes.rb
@@ -9,7 +9,7 @@ class TestAttributes < Minitest::Test
   def test_sourcepos
     sourcepos = []
 
-    @doc.walk do |node|
+    @doc.each do |node|
       sourcepos << node.sourcepos
     end
 

--- a/test/test_attributes.rb
+++ b/test/test_attributes.rb
@@ -9,7 +9,7 @@ class TestAttributes < Minitest::Test
   def test_sourcepos
     sourcepos = []
 
-    @doc.each do |node|
+    @doc.walk do |node|
       sourcepos << node.sourcepos
     end
 

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -7,10 +7,16 @@ class TestNode < Minitest::Test
 
   def test_walk
     nodes = []
-    @doc.walk do |node|
+    @doc.each do |node|
       nodes << node.type
     end
     assert_equal [:document, :paragraph, :text, :emph, :text], nodes
+  end
+
+  def test_select
+    nodes = @doc.select { |node| node.type == :text }
+    assert_equal CommonMarker::Node, nodes.first.class
+    assert_equal [:text, :text], nodes.map(&:type)
   end
 
   def test_insert_illegal
@@ -30,7 +36,7 @@ class TestNode < Minitest::Test
   end
 
   def test_walk_and_set_string_content
-    @doc.walk do |node|
+    @doc.each do |node|
       if node.type == :text && node.string_content == 'there'
         node.string_content = 'world'
         assert_equal 'world', node.string_content
@@ -39,7 +45,7 @@ class TestNode < Minitest::Test
   end
 
   def test_walk_and_delete_node
-    @doc.walk do |node|
+    @doc.each do |node|
       if node.type == :emph
         node.insert_before(node.first_child)
         node.delete

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -2,21 +2,42 @@ require 'test_helper'
 
 class TestNode < Minitest::Test
   def setup
-    @doc = CommonMarker.render_doc('Hi *there*')
+    @doc = CommonMarker.render_doc('Hi *there*, I am mostly text!')
   end
 
   def test_walk
     nodes = []
-    @doc.each do |node|
+    @doc.walk do |node|
       nodes << node.type
     end
-    assert_equal [:document, :paragraph, :text, :emph, :text], nodes
+    assert_equal [:document, :paragraph, :text, :emph, :text, :text, :text], nodes
+  end
+
+  def test_each
+    nodes = []
+    @doc.first_child.each do |node|
+      nodes << node.type
+    end
+    assert_equal [:text, :emph, :text, :text], nodes
+  end
+
+  def test_deprecated_each_child
+    nodes = []
+    @doc.first_child.each_child do |node|
+      nodes << node.type
+    end
+    assert_equal [:text, :emph, :text, :text], nodes
   end
 
   def test_select
-    nodes = @doc.select { |node| node.type == :text }
+    nodes = @doc.first_child.select { |node| node.type == :text }
     assert_equal CommonMarker::Node, nodes.first.class
-    assert_equal [:text, :text], nodes.map(&:type)
+    assert_equal [:text, :text, :text], nodes.map(&:type)
+  end
+
+  def test_map
+    nodes = @doc.first_child.map(&:type)
+    assert_equal [:text, :emph, :text, :text], nodes
   end
 
   def test_insert_illegal
@@ -26,36 +47,32 @@ class TestNode < Minitest::Test
   end
 
   def test_to_html
-    assert_equal "<p>Hi <em>there</em></p>\n", @doc.to_html
+    assert_equal "<p>Hi <em>there</em>, I am mostly text!</p>\n", @doc.to_html
   end
 
   def test_html_renderer
     renderer = HtmlRenderer.new
     result = renderer.render(@doc)
-    assert_equal "<p>Hi <em>there</em></p>\n", result
+    assert_equal "<p>Hi <em>there</em>, I am mostly text!</p>\n", result
   end
 
   def test_walk_and_set_string_content
-    @doc.each do |node|
+    @doc.walk do |node|
       if node.type == :text && node.string_content == 'there'
         node.string_content = 'world'
-        assert_equal 'world', node.string_content
       end
     end
+    result = HtmlRenderer.new.render(@doc)
+    assert_equal "<p>Hi <em>world</em>, I am mostly text!</p>\n", result
   end
 
   def test_walk_and_delete_node
-    @doc.each do |node|
+    @doc.walk do |node|
       if node.type == :emph
         node.insert_before(node.first_child)
         node.delete
       end
     end
-    assert_equal "<p>Hi there</p>\n", @doc.to_html
-  end
-
-  def test_markdown_to_html
-    html = CommonMarker.render_html('Hi *there*')
-    assert_equal "<p>Hi <em>there</em></p>\n", html
+    assert_equal "<p>Hi there, I am mostly text!</p>\n", @doc.to_html
   end
 end


### PR DESCRIPTION
Closes https://github.com/gjtorikian/commonmarker/issues/23.

@dgraham, how's this work for you? `walk` has been renamed `each` so that all the `Enumerable` methods can function. I only added a test for `select` but can add more if you think there's something to explicitly test.