### PR TITLE
support p and pp for CommonMarker::Node

### DIFF
--- a/lib/commonmarker/node.rb
+++ b/lib/commonmarker/node.rb
@@ -1,6 +1,9 @@
+require 'commonmarker/node/inspect'
+
 module CommonMarker
   class Node
     include Enumerable
+    include Inspect
 
     # Public: An iterator that "walks the tree," descending into children recursively.
     #

--- a/lib/commonmarker/node/inspect.rb
+++ b/lib/commonmarker/node/inspect.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'pp'
+
+module CommonMarker
+  class Node
+    module Inspect
+      PP_INDENT_SIZE = 2
+
+      def inspect
+        PP.pp(self, String.new, Float::INFINITY)
+      end
+
+      # @param [PrettyPrint] pp
+      def pretty_print(pp)
+        pp.group(PP_INDENT_SIZE, "#<#{self.class}(#{type}):", '>') do
+          pp.breakable
+
+          attrs = %i[
+            sourcepos
+            string_content
+            url
+            title
+            header_level
+            list_type
+            list_start
+            list_tight
+            fence_info
+          ].map do |name|
+            begin
+              [name, __send__(name)]
+            rescue NodeError
+              nil
+            end
+          end.compact
+
+          pp.seplist(attrs) do |name, value|
+            pp.text "#{name}="
+            pp.pp value
+          end
+
+          if first_child
+            pp.breakable
+            pp.group(PP_INDENT_SIZE) do
+              children = []
+              node = first_child
+              while node
+                children << node
+                node = node.next
+              end
+              pp.text 'children='
+              pp.pp children
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -78,4 +78,12 @@ class TestNode < Minitest::Test
     end
     assert_equal "<p>Hi there, I am mostly text!</p>\n", @doc.to_html
   end
+
+  def test_inspect
+    assert_match /#<CommonMarker::Node\(document\):/, @doc.inspect
+  end
+
+  def test_pretty_print
+    assert_match /#<CommonMarker::Node\(document\):/, PP.pp(@doc, '')
+  end
 end


### PR DESCRIPTION
Supporting pretty-printing / inspecting is inevitable for debugging.

Resolve #42 

## example

```sh
bundle exec ruby -Ilib -rcommonmarker -e 'pp CommonMarker.render_doc("Hi *there*, I am mostly text!")'
```

Shows:

```
#<CommonMarker::Node(document):
  sourcepos={:start_line=>1, :start_column=>1, :end_line=>1, :end_column=>29}
  children=[#<CommonMarker::Node(paragraph):
       sourcepos={:start_line=>1,
        :start_column=>1,
        :end_line=>1,
        :end_column=>29}
       children=[#<CommonMarker::Node(text):
            sourcepos={:start_line=>0,
             :start_column=>0,
             :end_line=>0,
             :end_column=>0},
            string_content="Hi ">,
          #<CommonMarker::Node(emph):
            sourcepos={:start_line=>0,
             :start_column=>0,
             :end_line=>0,
             :end_column=>0}
            children=[#<CommonMarker::Node(text):
                 sourcepos={:start_line=>0,
                  :start_column=>0,
                  :end_line=>0,
                  :end_column=>0},
                 string_content="there">]>,
          #<CommonMarker::Node(text):
            sourcepos={:start_line=>0,
             :start_column=>0,
             :end_line=>0,
             :end_column=>0},
            string_content=", I am mostly text">,
          #<CommonMarker::Node(text):
            sourcepos={:start_line=>0,
             :start_column=>0,
             :end_line=>0,
             :end_column=>0},
            string_content="!">]>]>
```