### PR TITLE
Plaintext renderer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ CommonMarker accepts the same options that CMark does, as symbols. Note that the
 | Name  |  Description |
 |-------|--------------|
 | `:DEFAULT`  | The default parsing system.  
-| `:NORMALIZE`  | Attempt to normalize the HTML.
 | `:SMART`  | Use smart punctuation (curly quotes, etc.).
 | `:VALIDATE_UTF8`  | Replace illegal sequences with the replacement character `U+FFFD`.
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ CommonMarker accepts the same options that CMark does, as symbols. Note that the
 | `:DEFAULT`  | The default parsing system.  
 | `:SMART`  | Use smart punctuation (curly quotes, etc.).
 | `:VALIDATE_UTF8`  | Replace illegal sequences with the replacement character `U+FFFD`.
+| `:LIBERAL_HTML_TAG`  | Support liberal parsing of inline HTML tags.
 
 ### Render options
 

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -570,6 +570,25 @@ static VALUE rb_render_commonmark(VALUE n, VALUE rb_options) {
   return ruby_cmark;
 }
 
+/* Internal: Convert the node to a plain textstring.
+ *
+ * Returns a {String}.
+ */
+static VALUE rb_render_plaintext(VALUE n, VALUE rb_options) {
+  int options;
+  cmark_node *node;
+  Check_Type(rb_options, T_FIXNUM);
+
+  options = FIX2INT(rb_options);
+  Data_Get_Struct(n, cmark_node, node);
+
+  char *text = cmark_render_plaintext(node, options, 120);
+  VALUE ruby_text = rb_str_new2(text);
+  free(text);
+
+  return ruby_text;
+}
+
 /*
  * Public: Inserts a node as a sibling after the current node.
  *
@@ -1080,6 +1099,7 @@ __attribute__((visibility("default"))) void Init_commonmarker() {
   rb_define_method(rb_mNode, "insert_before", rb_node_insert_before, 1);
   rb_define_method(rb_mNode, "_render_html", rb_render_html, 2);
   rb_define_method(rb_mNode, "_render_commonmark", rb_render_commonmark, 1);
+  rb_define_method(rb_mNode, "_render_plaintext", rb_render_plaintext, 1);
   rb_define_method(rb_mNode, "insert_after", rb_node_insert_after, 1);
   rb_define_method(rb_mNode, "prepend_child", rb_node_prepend_child, 1);
   rb_define_method(rb_mNode, "append_child", rb_node_append_child, 1);

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -6,7 +6,6 @@ module CommonMarker
       include Ruby::Enum
 
       define :DEFAULT, 0
-      define :NORMALIZE, (1 << 8)
       define :VALIDATE_UTF8, (1 << 9)
       define :SMART, (1 << 10)
       define :LIBERAL_HTML_TAG, (1 << 12)

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -9,6 +9,7 @@ module CommonMarker
       define :NORMALIZE, (1 << 8)
       define :VALIDATE_UTF8, (1 << 9)
       define :SMART, (1 << 10)
+      define :LIBERAL_HTML_TAG, (1 << 12)
     end
 
     class Render

--- a/lib/commonmarker/node.rb
+++ b/lib/commonmarker/node.rb
@@ -38,6 +38,16 @@ module CommonMarker
       _render_commonmark(opts).force_encoding('utf-8')
     end
 
+    # Public: Convert the node to a plain text string.
+    #
+    # options - A {Symbol} or {Array of Symbol}s indicating the render options
+    #
+    # Returns a {String}.
+    def to_plaintext(options = :DEFAULT)
+      opts = Config.process_options(options, :render)
+      _render_plaintext(opts).force_encoding('utf-8')
+    end
+
     # Public: Iterate over the children (if any) of the current pointer.
     def each(&block)
       return enum_for(:each) unless block_given?

--- a/lib/commonmarker/version.rb
+++ b/lib/commonmarker/version.rb
@@ -1,3 +1,3 @@
 module CommonMarker
-  VERSION = '0.15.0'.freeze
+  VERSION = '0.15.0.test1'.freeze
 end

--- a/lib/commonmarker/version.rb
+++ b/lib/commonmarker/version.rb
@@ -1,3 +1,3 @@
 module CommonMarker
-  VERSION = '0.15.0.test1'.freeze
+  VERSION = '0.15.0'.freeze
 end

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -10,7 +10,7 @@ class TestNode < Minitest::Test
     @doc.walk do |node|
       nodes << node.type
     end
-    assert_equal [:document, :paragraph, :text, :emph, :text, :text, :text], nodes
+    assert_equal [:document, :paragraph, :text, :emph, :text, :text], nodes
   end
 
   def test_each
@@ -18,7 +18,7 @@ class TestNode < Minitest::Test
     @doc.first_child.each do |node|
       nodes << node.type
     end
-    assert_equal [:text, :emph, :text, :text], nodes
+    assert_equal [:text, :emph, :text], nodes
   end
 
   def test_deprecated_each_child
@@ -28,19 +28,19 @@ class TestNode < Minitest::Test
         nodes << node.type
       end
     end
-    assert_equal [:text, :emph, :text, :text], nodes
+    assert_equal [:text, :emph, :text], nodes
     assert_match /`each_child` is deprecated/, err
   end
 
   def test_select
     nodes = @doc.first_child.select { |node| node.type == :text }
     assert_equal CommonMarker::Node, nodes.first.class
-    assert_equal [:text, :text, :text], nodes.map(&:type)
+    assert_equal [:text, :text], nodes.map(&:type)
   end
 
   def test_map
     nodes = @doc.first_child.map(&:type)
-    assert_equal [:text, :emph, :text, :text], nodes
+    assert_equal [:text, :emph, :text], nodes
   end
 
   def test_insert_illegal

--- a/test/test_plaintext.rb
+++ b/test/test_plaintext.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class TestPlaintext < Minitest::Test
+  def setup
+    @markdown = <<-MD
+Hi *there*!
+
+1. I am a numeric list.
+2. I continue the list.
+* Suddenly, an unordered list!
+* What fun!
+
+Okay, _enough_.
+
+| a   | b   |
+| --- | --- |
+| c   | d   |
+    MD
+  end
+
+  def render_doc(doc)
+    CommonMarker.render_doc(doc, :DEFAULT, %i[table])
+  end
+
+  def test_to_commonmark
+    compare = render_doc(@markdown).to_plaintext
+
+    assert_equal <<-PLAINTEXT, compare
+Hi there!
+
+1.  I am a numeric list.
+2.  I continue the list.
+
+  - Suddenly, an unordered list!
+  - What fun!
+
+Okay, enough.
+
+| a | b |
+| --- | --- |
+| c | d |
+      PLAINTEXT
+  end
+end


### PR DESCRIPTION
`cmark-gfm` got plaintext rendering support! We also lost an option, and gained one.