### PR TITLE
Full support for options and extensions in HtmlRenderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,21 +127,23 @@ CommonMarker accepts the same options that CMark does, as symbols. Note that the
 
 ### Parse options
 
-| Name  |  Description |
-|-------|--------------|
-| `:DEFAULT`  | The default parsing system.  
-| `:SMART`  | Use smart punctuation (curly quotes, etc.).
-| `:VALIDATE_UTF8`  | Replace illegal sequences with the replacement character `U+FFFD`.
-| `:LIBERAL_HTML_TAG`  | Support liberal parsing of inline HTML tags.
+| Name                | Description
+| ------------------- | -----------
+| `:DEFAULT`          | The default parsing system.
+| `:SMART`            | Use smart punctuation (curly quotes, etc.).
+| `:VALIDATE_UTF8`    | Replace illegal sequences with the replacement character `U+FFFD`.
+| `:LIBERAL_HTML_TAG` | Support liberal parsing of inline HTML tags.
 
 ### Render options
 
-| Name  |  Description |
-|-------|--------------|
-| `:DEFAULT`  | The default rendering system.
-| `:SOURCEPOS` |  Include source position in rendered HTML.
-| `:HARDBREAKS`  | Treat `\n` as hardbreaks (by adding `<br/>`).
-| `:SAFE`  | Suppress raw HTML and unsafe links.
+| Name               | Description
+| ------------------ | -----------
+| `:DEFAULT`         | The default rendering system.
+| `:SOURCEPOS`       | Include source position in rendered HTML.
+| `:HARDBREAKS`      | Treat `\n` as hardbreaks (by adding `<br/>`).
+| `:NOBREAKS`        | Translate `\n` in the source to a single whitespace.
+| `:SAFE`            | Suppress raw HTML and unsafe links.
+| `:GITHUB_PRE_LANG` | Use GitHub-style `<pre lang>` for fenced code blocks.
 
 ### Passing options
 

--- a/bin/commonmarker
+++ b/bin/commonmarker
@@ -30,7 +30,7 @@ active_extensions = []
 renderer = nil
 ARGV.delete_if do |arg|
   if arg =~ /^--html-renderer$/
-    renderer = CommonMarker::HtmlRenderer.new
+    renderer = true
     true
   elsif arg =~ /^--list-extensions$/
     puts extensions
@@ -51,6 +51,7 @@ end
 doc = CommonMarker.render_doc(ARGF.read, :DEFAULT, active_extensions)
 
 if renderer
+  renderer = CommonMarker::HtmlRenderer.new(extensions: active_extensions)
   STDOUT.write(renderer.render(doc))
 else
   STDOUT.write(doc.to_html(:DEFAULT, active_extensions))

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -1005,7 +1005,7 @@ static VALUE rb_node_set_fence_info(VALUE self, VALUE info) {
 }
 
 static VALUE rb_node_get_table_alignments(VALUE self) {
-  uint16_t column_count;
+  uint16_t column_count, i;
   uint8_t *alignments;
   cmark_node *node;
   VALUE ary;
@@ -1019,7 +1019,7 @@ static VALUE rb_node_get_table_alignments(VALUE self) {
   }
 
   ary = rb_ary_new();
-  for (uint16_t i = 0; i < column_count; ++i) {
+  for (i = 0; i < column_count; ++i) {
     if (alignments[i] == 'l')
       rb_ary_push(ary, sym_left);
     else if (alignments[i] == 'c')

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -32,6 +32,10 @@ static VALUE sym_image;
 static VALUE sym_bullet_list;
 static VALUE sym_ordered_list;
 
+static VALUE sym_left;
+static VALUE sym_right;
+static VALUE sym_center;
+
 static VALUE encode_utf8_string(const char *c_string) {
   VALUE string = rb_str_new2(c_string);
   int enc = rb_enc_find_index("UTF-8");
@@ -1000,6 +1004,33 @@ static VALUE rb_node_set_fence_info(VALUE self, VALUE info) {
   return Qnil;
 }
 
+static VALUE rb_node_get_table_alignments(VALUE self) {
+  uint16_t column_count;
+  uint8_t *alignments;
+  cmark_node *node;
+  VALUE ary;
+  Data_Get_Struct(self, cmark_node, node);
+
+  column_count = cmarkextensions_get_table_columns(node);
+  alignments = cmarkextensions_get_table_alignments(node);
+
+  if (!column_count || !alignments) {
+    rb_raise(rb_mNodeError, "could not get column_count or alignments");
+  }
+
+  ary = rb_ary_new();
+  for (uint16_t i = 0; i < column_count; ++i) {
+    if (alignments[i] == 'l')
+      rb_ary_push(ary, sym_left);
+    else if (alignments[i] == 'c')
+      rb_ary_push(ary, sym_center);
+    else if (alignments[i] == 'r')
+      rb_ary_push(ary, sym_right);
+    else
+      rb_ary_push(ary, Qnil);
+  }
+  return ary;
+}
 /* Internal: Escapes href URLs safely. */
 static VALUE rb_html_escape_href(VALUE self, VALUE rb_text) {
   char *result;
@@ -1080,6 +1111,10 @@ __attribute__((visibility("default"))) void Init_commonmarker() {
   sym_bullet_list = ID2SYM(rb_intern("bullet_list"));
   sym_ordered_list = ID2SYM(rb_intern("ordered_list"));
 
+  sym_left = ID2SYM(rb_intern("left"));
+  sym_right = ID2SYM(rb_intern("right"));
+  sym_center = ID2SYM(rb_intern("center"));
+
   module = rb_define_module("CommonMarker");
   rb_define_singleton_method(module, "extensions", rb_extensions, 0);
   rb_mNodeError = rb_define_class_under(module, "NodeError", rb_eStandardError);
@@ -1120,6 +1155,7 @@ __attribute__((visibility("default"))) void Init_commonmarker() {
   rb_define_method(rb_mNode, "list_tight=", rb_node_set_list_tight, 1);
   rb_define_method(rb_mNode, "fence_info", rb_node_get_fence_info, 0);
   rb_define_method(rb_mNode, "fence_info=", rb_node_set_fence_info, 1);
+  rb_define_method(rb_mNode, "table_alignments", rb_node_get_table_alignments, 0);
 
   rb_define_method(rb_mNode, "html_escape_href", rb_html_escape_href, 1);
   rb_define_method(rb_mNode, "html_escape_html", rb_html_escape_html, 1);

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -1031,6 +1031,7 @@ static VALUE rb_node_get_table_alignments(VALUE self) {
   }
   return ary;
 }
+
 /* Internal: Escapes href URLs safely. */
 static VALUE rb_html_escape_href(VALUE self, VALUE rb_text) {
   char *result;

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -18,6 +18,7 @@ module CommonMarker
       define :SOURCEPOS, (1 << 1)
       define :HARDBREAKS, (1 << 2)
       define :SAFE, (1 << 3)
+      define :NOBREAKS, (1 << 4)
       define :GITHUB_PRE_LANG, (1 << 11)
     end
 

--- a/lib/commonmarker/renderer.rb
+++ b/lib/commonmarker/renderer.rb
@@ -11,7 +11,6 @@ module CommonMarker
       @warnings = Set.new []
       @in_tight = false
       @in_plain = false
-      @buffer = ''
       @tagfilter = extensions.include?(:tagfilter)
     end
 
@@ -24,7 +23,6 @@ module CommonMarker
         elsif arg.is_a?(Node)
           render(arg)
         else
-          @buffer << arg.to_s.force_encoding('utf-8')
           @stream.write(arg)
         end
       end
@@ -59,7 +57,7 @@ module CommonMarker
     end
 
     def cr
-      return if @buffer.empty? || @buffer[-1] == "\n"
+      return if @stream.string.empty? || @stream.string[-1] == "\n"
       out("\n")
     end
 

--- a/lib/commonmarker/renderer.rb
+++ b/lib/commonmarker/renderer.rb
@@ -116,13 +116,14 @@ module CommonMarker
     end
 
     def sourcepos(node)
-      if @opts & CommonMarker::Config::Render::SOURCEPOS != 0
-        s = node.sourcepos
-        " data-sourcepos=\"#{s[:start_line]}:#{s[:start_column]}-" \
-          "#{s[:end_line]}:#{s[:end_column]}\""
-      else
-        ""
-      end
+      return "" unless option_enabled?(:SOURCEPOS)
+      s = node.sourcepos
+      " data-sourcepos=\"#{s[:start_line]}:#{s[:start_column]}-" \
+        "#{s[:end_line]}:#{s[:end_column]}\""
+    end
+
+    def option_enabled?(opt)
+      (@opts & CommonMarker::Config::Render.value(opt)) != 0
     end
   end
 end

--- a/lib/commonmarker/renderer.rb
+++ b/lib/commonmarker/renderer.rb
@@ -4,13 +4,14 @@ require 'stringio'
 module CommonMarker
   class Renderer
     attr_accessor :in_tight, :warnings, :in_plain
-    def initialize
+    def initialize(extensions: [])
       @stream = StringIO.new("".force_encoding("utf-8"))
       @need_blocksep = false
       @warnings = Set.new []
       @in_tight = false
       @in_plain = false
       @buffer = ''
+      @tagfilter = extensions.include?(:tagfilter)
     end
 
     def out(*args)
@@ -96,6 +97,23 @@ module CommonMarker
 
     def escape_html(str)
       @node.html_escape_html(str)
+    end
+
+    def tagfilter(str)
+      if @tagfilter
+        str.gsub(
+          %r{
+            <
+            (
+            title|textarea|style|xmp|iframe|
+            noembed|noframes|script|plaintext
+            )
+            (?=\s|>|/>)
+          }x,
+          '&lt;\1')
+      else
+        str
+      end
     end
   end
 end

--- a/lib/commonmarker/renderer.rb
+++ b/lib/commonmarker/renderer.rb
@@ -4,7 +4,8 @@ require 'stringio'
 module CommonMarker
   class Renderer
     attr_accessor :in_tight, :warnings, :in_plain
-    def initialize(extensions: [])
+    def initialize(options: :DEFAULT, extensions: [])
+      @opts = Config.process_options(options, :render)
       @stream = StringIO.new("".force_encoding("utf-8"))
       @need_blocksep = false
       @warnings = Set.new []

--- a/lib/commonmarker/renderer.rb
+++ b/lib/commonmarker/renderer.rb
@@ -116,5 +116,15 @@ module CommonMarker
         str
       end
     end
+
+    def sourcepos(node)
+      if @opts & CommonMarker::Config::Render::SOURCEPOS != 0
+        s = node.sourcepos
+        " data-sourcepos=\"#{s[:start_line]}:#{s[:start_column]}-" \
+          "#{s[:end_line]}:#{s[:end_column]}\""
+      else
+        ""
+      end
+    end
   end
 end

--- a/lib/commonmarker/renderer/html_renderer.rb
+++ b/lib/commonmarker/renderer/html_renderer.rb
@@ -92,12 +92,20 @@ module CommonMarker
 
     def html(node)
       block do
-        out(tagfilter(node.string_content))
+        if @opts & CommonMarker::Config::Render::SAFE != 0
+          out('<!-- raw HTML omitted -->')
+        else
+          out(tagfilter(node.string_content))
+        end
       end
     end
 
     def inline_html(node)
-      out(tagfilter(node.string_content))
+      if @opts & CommonMarker::Config::Render::SAFE != 0
+        out('<!-- raw HTML omitted -->')
+      else
+        out(tagfilter(node.string_content))
+      end
     end
 
     def emph(_)
@@ -138,12 +146,17 @@ module CommonMarker
     end
 
     def linebreak(node)
-      out('<br />')
-      softbreak(node)
+      out("<br />\n")
     end
 
     def softbreak(_)
-      out("\n")
+      if @opts & CommonMarker::Config::Render::HARDBREAKS != 0
+        out("<br />\n")
+      elsif @opts & CommonMarker::Config::Render::NOBREAKS != 0
+        out(' ')
+      else
+        out("\n")
+      end
     end
 
     def table(node)

--- a/lib/commonmarker/renderer/html_renderer.rb
+++ b/lib/commonmarker/renderer/html_renderer.rb
@@ -138,22 +138,33 @@ module CommonMarker
       out("\n")
     end
 
-    def table(_)
+    def table(node)
+      @alignments = node.table_alignments
       out("<table>\n", :children, "</tbody></table>\n")
     end
 
     def table_header(_)
+      @column_index = 0
+
       @in_header = true
       out("<thead>\n<tr>", :children, "\n</tr>\n</thead>\n<tbody>")
       @in_header = false
     end
 
     def table_row(_)
+      @column_index = 0
       out("\n<tr>", :children, "\n</tr>")
     end
 
     def table_cell(_)
-      out(@in_header ? "\n<th>" : "\n<td>", :children, @in_header ? "</th>" : "</td>")
+      align = case @alignments[@column_index]
+              when :left; ' align="left"'
+              when :right; ' align="right"'
+              when :center; ' align="center"'
+              else; ''
+              end
+      out(@in_header ? "\n<th#{align}>" : "\n<td#{align}>", :children, @in_header ? "</th>" : "</td>")
+      @column_index += 1
     end
 
     def strikethrough(_)

--- a/lib/commonmarker/renderer/html_renderer.rb
+++ b/lib/commonmarker/renderer/html_renderer.rb
@@ -71,7 +71,7 @@ module CommonMarker
 
     def code_block(node)
       block do
-        if @opts & CommonMarker::Config::Render::GITHUB_PRE_LANG != 0
+        if option_enabled?(:GITHUB_PRE_LANG)
           out("<pre#{sourcepos(node)}")
           if node.fence_info && !node.fence_info.empty?
             out(' lang="', node.fence_info.split(/\s+/)[0], '"')
@@ -92,7 +92,7 @@ module CommonMarker
 
     def html(node)
       block do
-        if @opts & CommonMarker::Config::Render::SAFE != 0
+        if option_enabled?(:SAFE)
           out('<!-- raw HTML omitted -->')
         else
           out(tagfilter(node.string_content))
@@ -101,7 +101,7 @@ module CommonMarker
     end
 
     def inline_html(node)
-      if @opts & CommonMarker::Config::Render::SAFE != 0
+      if option_enabled?(:SAFE)
         out('<!-- raw HTML omitted -->')
       else
         out(tagfilter(node.string_content))
@@ -150,9 +150,9 @@ module CommonMarker
     end
 
     def softbreak(_)
-      if @opts & CommonMarker::Config::Render::HARDBREAKS != 0
+      if option_enabled?(:HARDBREAKS)
         out("<br />\n")
-      elsif @opts & CommonMarker::Config::Render::NOBREAKS != 0
+      elsif option_enabled?(:NOBREAKS)
         out(' ')
       else
         out("\n")

--- a/lib/commonmarker/renderer/html_renderer.rb
+++ b/lib/commonmarker/renderer/html_renderer.rb
@@ -84,12 +84,12 @@ module CommonMarker
 
     def html(node)
       block do
-        out(node.string_content)
+        out(tagfilter(node.string_content))
       end
     end
 
     def inline_html(node)
-      out(node.string_content)
+      out(tagfilter(node.string_content))
     end
 
     def emph(_)

--- a/lib/commonmarker/renderer/html_renderer.rb
+++ b/lib/commonmarker/renderer/html_renderer.rb
@@ -71,11 +71,19 @@ module CommonMarker
 
     def code_block(node)
       block do
-        out('<pre><code')
-        if node.fence_info && !node.fence_info.empty?
-          out(' class="language-', node.fence_info.split(/\s+/)[0], '">')
+        if @opts & CommonMarker::Config::Render::GITHUB_PRE_LANG != 0
+          out('<pre')
+          if node.fence_info && !node.fence_info.empty?
+            out(' lang="', node.fence_info.split(/\s+/)[0], '"')
+          end
+          out('><code>')
         else
-          out('>')
+          out('<pre><code')
+          if node.fence_info && !node.fence_info.empty?
+            out(' class="language-', node.fence_info.split(/\s+/)[0], '">')
+          else
+            out('>')
+          end
         end
         out(escape_html(node.string_content))
         out('</code></pre>')

--- a/lib/commonmarker/renderer/html_renderer.rb
+++ b/lib/commonmarker/renderer/html_renderer.rb
@@ -139,25 +139,25 @@ module CommonMarker
     end
 
     def table(_)
-      out('<table>', :children, '</tbody></table>')
+      out("<table>\n", :children, "</tbody></table>\n")
     end
 
     def table_header(_)
       @in_header = true
-      out('<thead>', :children, '</thead><tbody>')
+      out("<thead>\n<tr>", :children, "\n</tr>\n</thead>\n<tbody>")
       @in_header = false
     end
 
     def table_row(_)
-      out('<tr>', :children, '</tr>')
+      out("\n<tr>", :children, "\n</tr>")
     end
 
     def table_cell(_)
-      out(@in_header ? '<th>' : '<td>', :children, @in_header ? '</th>' : '</td>')
+      out(@in_header ? "\n<th>" : "\n<td>", :children, @in_header ? "</th>" : "</td>")
     end
 
     def strikethrough(_)
-      out('<strike>', :children, '</strike>')
+      out('<del>', :children, '</del>')
     end
   end
 end

--- a/lib/commonmarker/renderer/html_renderer.rb
+++ b/lib/commonmarker/renderer/html_renderer.rb
@@ -6,7 +6,7 @@ module CommonMarker
 
     def header(node)
       block do
-        out('<h', node.header_level, '>', :children,
+        out('<h', node.header_level, "#{sourcepos(node)}>", :children,
             '</h', node.header_level, '>')
       end
     end
@@ -16,7 +16,7 @@ module CommonMarker
         out(:children)
       else
         block do
-          container('<p>', '</p>') do
+          container("<p#{sourcepos(node)}>", '</p>') do
             out(:children)
           end
         end
@@ -29,14 +29,14 @@ module CommonMarker
 
       block do
         if node.list_type == :bullet_list
-          container("<ul>\n", '</ul>') do
+          container("<ul#{sourcepos(node)}>\n", '</ul>') do
             out(:children)
           end
         else
           start = if node.list_start == 1
-                    "<ol>\n"
+                    "<ol#{sourcepos(node)}>\n"
                   else
-                    "<ol start=\"#{node.list_start}\">\n"
+                    "<ol start=\"#{node.list_start}\"#{sourcepos(node)}>\n"
                   end
           container(start, '</ol>') do
             out(:children)
@@ -47,38 +47,38 @@ module CommonMarker
       @in_tight = old_in_tight
     end
 
-    def list_item(_)
+    def list_item(node)
       block do
-        container('<li>', '</li>') do
+        container("<li#{sourcepos(node)}>", '</li>') do
           out(:children)
         end
       end
     end
 
-    def blockquote(_)
+    def blockquote(node)
       block do
-        container("<blockquote>\n", '</blockquote>') do
+        container("<blockquote#{sourcepos(node)}>\n", '</blockquote>') do
           out(:children)
         end
       end
     end
 
-    def hrule(_)
+    def hrule(node)
       block do
-        out('<hr />')
+        out("<hr#{sourcepos(node)} />")
       end
     end
 
     def code_block(node)
       block do
         if @opts & CommonMarker::Config::Render::GITHUB_PRE_LANG != 0
-          out('<pre')
+          out("<pre#{sourcepos(node)}")
           if node.fence_info && !node.fence_info.empty?
             out(' lang="', node.fence_info.split(/\s+/)[0], '"')
           end
           out('><code>')
         else
-          out('<pre><code')
+          out("<pre#{sourcepos(node)}><code")
           if node.fence_info && !node.fence_info.empty?
             out(' class="language-', node.fence_info.split(/\s+/)[0], '">')
           else
@@ -161,30 +161,30 @@ module CommonMarker
 
     def table(node)
       @alignments = node.table_alignments
-      out("<table>\n", :children, "</tbody></table>\n")
+      out("<table#{sourcepos(node)}>\n", :children, "</tbody></table>\n")
     end
 
-    def table_header(_)
+    def table_header(node)
       @column_index = 0
 
       @in_header = true
-      out("<thead>\n<tr>", :children, "\n</tr>\n</thead>\n<tbody>")
+      out("<thead>\n<tr#{sourcepos(node)}>", :children, "\n</tr>\n</thead>\n<tbody>")
       @in_header = false
     end
 
-    def table_row(_)
+    def table_row(node)
       @column_index = 0
-      out("\n<tr>", :children, "\n</tr>")
+      out("\n<tr#{sourcepos(node)}>", :children, "\n</tr>")
     end
 
-    def table_cell(_)
+    def table_cell(node)
       align = case @alignments[@column_index]
               when :left; ' align="left"'
               when :right; ' align="right"'
               when :center; ' align="center"'
               else; ''
               end
-      out(@in_header ? "\n<th#{align}>" : "\n<td#{align}>", :children, @in_header ? "</th>" : "</td>")
+      out(@in_header ? "\n<th#{align}#{sourcepos(node)}>" : "\n<td#{align}#{sourcepos(node)}>", :children, @in_header ? "</th>" : "</td>")
       @column_index += 1
     end
 

--- a/test/test_spec.rb
+++ b/test/test_spec.rb
@@ -13,13 +13,11 @@ class TestSpec < Minitest::Test
       assert_equal testcase[:html], actual, testcase[:markdown]
     end
 
-    unless testcase[:extensions].any?
-      define_method("test_html_renderer_example_#{testcase[:example]}") do
-        actual = HtmlRenderer.new.render(doc).rstrip
-        File.write('test.txt', testcase[:html])
-        File.write('actual.txt', actual)
-        assert_equal testcase[:html], actual, testcase[:markdown]
-      end
+    define_method("test_html_renderer_example_#{testcase[:example]}") do
+      actual = HtmlRenderer.new.render(doc).rstrip
+      File.write('test.txt', testcase[:html])
+      File.write('actual.txt', actual)
+      assert_equal testcase[:html], actual, testcase[:markdown]
     end
   end
 end

--- a/test/test_spec.rb
+++ b/test/test_spec.rb
@@ -15,9 +15,13 @@ class TestSpec < Minitest::Test
 
     define_method("test_html_renderer_example_#{testcase[:example]}") do
       actual = HtmlRenderer.new(extensions: testcase[:extensions]).render(doc).rstrip
-      File.write('test.txt', testcase[:html])
-      File.write('actual.txt', actual)
       assert_equal testcase[:html], actual, testcase[:markdown]
+    end
+
+    define_method("test_sourcepos_example_#{testcase[:example]}") do
+      lhs = doc.to_html(:SOURCEPOS, testcase[:extensions]).rstrip
+      rhs = HtmlRenderer.new(options: :SOURCEPOS, extensions: testcase[:extensions]).render(doc).rstrip
+      assert_equal lhs, rhs, testcase[:markdown]
     end
   end
 end

--- a/test/test_spec.rb
+++ b/test/test_spec.rb
@@ -14,7 +14,7 @@ class TestSpec < Minitest::Test
     end
 
     define_method("test_html_renderer_example_#{testcase[:example]}") do
-      actual = HtmlRenderer.new.render(doc).rstrip
+      actual = HtmlRenderer.new(extensions: testcase[:extensions]).render(doc).rstrip
       File.write('test.txt', testcase[:html])
       File.write('actual.txt', actual)
       assert_equal testcase[:html], actual, testcase[:markdown]


### PR DESCRIPTION
There was some incomplete support, this is just rounding it off and enabling it on all the same tests we put the normal renderer through.

Most of it doesn't actually need to be switched on or off specially — we rely on the fact that e.g. we'll only get a `strikethrough` or `table_cell` node if the parser had that enabled in the first place. The only switch we do have which is renderer-specific is `tagfilter`.

/cc @gjtorikian for review