### PR TITLE
Update link to the CMark docs options

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ To have multiple options applied, pass in an array of symbols:
 CommonMarker.render_html("\"'Shelob' is my name.\"", [:HARDBREAKS, :SOURCEPOS])
 ```
 
-For more information on these options, see [the CMark documentation](http://git.io/vlQii).
+For more information on these options, see [the CMark documentation](https://git.io/v7nh1).
 
 ## Hacking
 


### PR DESCRIPTION
The link referencing the CMark docs drifted by a few dozen lines, this one updates it to the current one. We could also point it to a specific commit with [this link](https://git.io/v7nhN) if you'd prefer. Could not label this PR, should probably be filed under "huge nitpick", or "documentation drive-thru". Haven't read the rest of the source code yet, when my inner reviewer kicked in. I should probably stop githubbing after work. ANYWAY, yay open source!