### PR TITLE
Fix issues with tables during a round-trip parsing CM and then producing CM again.

### DIFF
--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -592,7 +592,7 @@ static VALUE rb_render_commonmark(int argc, VALUE *argv, VALUE n) {
   VALUE ruby_cmark = rb_str_new2(cmark);
   free(cmark);
 
-  return ruby_cmark;  
+  return ruby_cmark;
 }
 
 /* Internal: Convert the node to a plain textstring.

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -579,7 +579,7 @@ static VALUE rb_render_commonmark(VALUE n, VALUE rb_options) {
   options = FIX2INT(rb_options);
   Data_Get_Struct(n, cmark_node, node);
 
-  char *cmark = cmark_render_commonmark(node, options, 120);
+  char *cmark = cmark_render_commonmark(node, options, 0);
   VALUE ruby_cmark = rb_str_new2(cmark);
   free(cmark);
 

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -571,7 +571,16 @@ static VALUE rb_render_html(VALUE n, VALUE rb_options, VALUE rb_extensions) {
  *
  * Returns a {String}.
  */
-static VALUE rb_render_commonmark(VALUE n, VALUE rb_options) {
+static VALUE rb_render_commonmark(int argc, VALUE *argv, VALUE n) {
+  VALUE rb_options, rb_width;
+  rb_scan_args(argc, argv, "11", &rb_options, &rb_width);
+
+  int width = 120;
+  if (!NIL_P(rb_width)) {
+    Check_Type(rb_width, T_FIXNUM);
+    width = FIX2INT(rb_width);
+  }
+
   int options;
   cmark_node *node;
   Check_Type(rb_options, T_FIXNUM);
@@ -579,18 +588,27 @@ static VALUE rb_render_commonmark(VALUE n, VALUE rb_options) {
   options = FIX2INT(rb_options);
   Data_Get_Struct(n, cmark_node, node);
 
-  char *cmark = cmark_render_commonmark(node, options, 0);
+  char *cmark = cmark_render_commonmark(node, options, width);
   VALUE ruby_cmark = rb_str_new2(cmark);
   free(cmark);
 
-  return ruby_cmark;
+  return ruby_cmark;  
 }
 
 /* Internal: Convert the node to a plain textstring.
  *
  * Returns a {String}.
  */
-static VALUE rb_render_plaintext(VALUE n, VALUE rb_options) {
+static VALUE rb_render_plaintext(int argc, VALUE *argv, VALUE n) {
+  VALUE rb_options, rb_width;
+  rb_scan_args(argc, argv, "11", &rb_options, &rb_width);
+
+  int width = 120;
+  if (!NIL_P(rb_width)) {
+    Check_Type(rb_width, T_FIXNUM);
+    width = FIX2INT(rb_width);
+  }
+
   int options;
   cmark_node *node;
   Check_Type(rb_options, T_FIXNUM);
@@ -598,7 +616,7 @@ static VALUE rb_render_plaintext(VALUE n, VALUE rb_options) {
   options = FIX2INT(rb_options);
   Data_Get_Struct(n, cmark_node, node);
 
-  char *text = cmark_render_plaintext(node, options, 120);
+  char *text = cmark_render_plaintext(node, options, width);
   VALUE ruby_text = rb_str_new2(text);
   free(text);
 
@@ -1148,8 +1166,8 @@ __attribute__((visibility("default"))) void Init_commonmarker() {
   rb_define_method(rb_mNode, "next", rb_node_next, 0);
   rb_define_method(rb_mNode, "insert_before", rb_node_insert_before, 1);
   rb_define_method(rb_mNode, "_render_html", rb_render_html, 2);
-  rb_define_method(rb_mNode, "_render_commonmark", rb_render_commonmark, 1);
-  rb_define_method(rb_mNode, "_render_plaintext", rb_render_plaintext, 1);
+  rb_define_method(rb_mNode, "_render_commonmark", rb_render_commonmark, -1);
+  rb_define_method(rb_mNode, "_render_plaintext", rb_render_plaintext, -1);
   rb_define_method(rb_mNode, "insert_after", rb_node_insert_after, 1);
   rb_define_method(rb_mNode, "prepend_child", rb_node_prepend_child, 1);
   rb_define_method(rb_mNode, "append_child", rb_node_append_child, 1);

--- a/lib/commonmarker/node.rb
+++ b/lib/commonmarker/node.rb
@@ -31,21 +31,23 @@ module CommonMarker
     # Public: Convert the node to a CommonMark string.
     #
     # options - A {Symbol} or {Array of Symbol}s indicating the render options
+    # width - Column to wrap the output at
     #
     # Returns a {String}.
-    def to_commonmark(options = :DEFAULT)
+    def to_commonmark(options = :DEFAULT, width = 120)
       opts = Config.process_options(options, :render)
-      _render_commonmark(opts).force_encoding('utf-8')
+      _render_commonmark(opts, width).force_encoding('utf-8')
     end
 
     # Public: Convert the node to a plain text string.
     #
     # options - A {Symbol} or {Array of Symbol}s indicating the render options
+    # width - Column to wrap the output at
     #
     # Returns a {String}.
-    def to_plaintext(options = :DEFAULT)
+    def to_plaintext(options = :DEFAULT, width = 120)
       opts = Config.process_options(options, :render)
-      _render_plaintext(opts).force_encoding('utf-8')
+      _render_plaintext(opts, width).force_encoding('utf-8')
     end
 
     # Public: Iterate over the children (if any) of the current pointer.


### PR DESCRIPTION
When parsing Commonmark, traversing the nodes and then re-generating Commonmark, table rows longer than 120 characters are broken as a result of the hard-coded column wrapping.

This patch introduces an optional rendering parameter to specify the width, so callers can opt for "0" to omit all wrapping when necessary (_or choose a different wrapping column as desired_).