### PR TITLE
Remove square brackets when rendering HTML for footnotes

### DIFF
--- a/ext/commonmarker/html.c
+++ b/ext/commonmarker/html.c
@@ -406,9 +406,9 @@ static int S_render_node(cmark_html_renderer *renderer, cmark_node *node,
       cmark_strbuf_put(html, node->as.literal.data, node->as.literal.len);
       cmark_strbuf_puts(html, "\" id=\"fnref");
       cmark_strbuf_put(html, node->as.literal.data, node->as.literal.len);
-      cmark_strbuf_puts(html, "\">[");
+      cmark_strbuf_puts(html, "\">");
       cmark_strbuf_put(html, node->as.literal.data, node->as.literal.len);
-      cmark_strbuf_puts(html, "]</a></sup>");
+      cmark_strbuf_puts(html, "</a></sup>");
     }
     break;
 

--- a/lib/commonmarker/renderer/html_renderer.rb
+++ b/lib/commonmarker/renderer/html_renderer.rb
@@ -211,7 +211,7 @@ module CommonMarker
     end
 
     def footnote_reference(node)
-      out("<sup class=\"footnote-ref\"><a href=\"#fn#{node.string_content}\" id=\"fnref#{node.string_content}\">[#{node.string_content}]</a></sup>")
+      out("<sup class=\"footnote-ref\"><a href=\"#fn#{node.string_content}\" id=\"fnref#{node.string_content}\">#{node.string_content}</a></sup>")
     end
 
     def footnote_definition(_)

--- a/test/test_footnotes.rb
+++ b/test/test_footnotes.rb
@@ -4,7 +4,7 @@ class TestFootnotes < Minitest::Test
   def setup
     @doc = CommonMarker.render_doc("Hello[^hi].\n\n[^hi]: Hey!\n", :FOOTNOTES)
     @expected = <<-HTML
-<p>Hello<sup class="footnote-ref"><a href="#fn1" id="fnref1">[1]</a></sup>.</p>
+<p>Hello<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup>.</p>
 <section class="footnotes">
 <ol>
 <li id="fn1">


### PR DESCRIPTION
The current HTML renderer outputs square brackets around footnotes.
```html
This is a test.<sup class="footnote-ref"><a href="#fn1" id="fnref1">[1]</a></sup>
```
This is not consistent with Kramdown's rendering (see [Babelmark](http://johnmacfarlane.net/babelmark2/?text=This+is+a+test.%5B%5E1%5D%0A%0A%5B%5E1%5D%3A+Of+footnotes.)). I assume that this should be considered a bug given that the purpose of introducing the change was [to allow the Cmark renderer to be used in place of Kramdown](https://github.com/github/cmark/pull/64#issue-151303356). It also just looks weird.

Since the bug is in the Cmark project perhaps it would be best to suggest the fix there? Sorry, this is the first time I've tried to do something like this so I'm not sure. I came across the issue when using CommonMarker and so it felt most natural to make the PR to this project.