### PR TITLE
Fix options

### DIFF
--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -21,7 +21,12 @@ module CommonMarker
       define :HARDBREAKS, (1 << 2)
       define :SAFE, (1 << 3)
       define :NOBREAKS, (1 << 4)
+      define :VALIDATE_UTF8, (1 << 9)
       define :GITHUB_PRE_LANG, (1 << 11)
+      define :SMART, (1 << 10)
+      define :LIBERAL_HTML_TAG, (1 << 12)
+      define :FOOTNOTES, (1 << 13)
+      define :STRIKETHROUGH_DOUBLE_TILDE, (1 << 14)
       define :TABLE_PREFER_STYLE_ATTRIBUTES, (1 << 15)
     end
 

--- a/test/test_maliciousness.rb
+++ b/test/test_maliciousness.rb
@@ -64,11 +64,6 @@ class CommonMarker::TestMaliciousness < Minitest::Test
       CommonMarker.render_html(nil)
     end
 
-    err = assert_raises TypeError do
-      CommonMarker.render_html("foo \n baz", [:SMART])
-    end
-    assert_equal err.message, 'option \':SMART\' does not exist for CommonMarker::Config::Render'
-
     assert_raises TypeError do
       CommonMarker.render_doc("foo \n baz", 123)
     end


### PR DESCRIPTION
The parse options are also valid for `render_html`, because
`render_html` calls the parser underneath.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gjtorikian/commonmarker/70)
<!-- Reviewable:end -->
