### PR TITLE
Bring in plaintext strikethrough rendering fix

### DIFF
--- a/ext/commonmarker/cmark_version.h
+++ b/ext/commonmarker/cmark_version.h
@@ -1,8 +1,8 @@
 #ifndef CMARK_VERSION_H
 #define CMARK_VERSION_H
 
-#define CMARK_VERSION ((0 << 24) | (28 << 16) | (3 << 8) | 12)
-#define CMARK_VERSION_STRING "0.28.3.gfm.12"
-#define CMARK_GFM_VERSION 12
+#define CMARK_VERSION ((0 << 24) | (28 << 16) | (3 << 8) | 14)
+#define CMARK_VERSION_STRING "0.28.3.gfm.14"
+#define CMARK_GFM_VERSION 14
 
 #endif

--- a/ext/commonmarker/strikethrough.c
+++ b/ext/commonmarker/strikethrough.c
@@ -133,6 +133,12 @@ static void html_render(cmark_syntax_extension *extension,
   }
 }
 
+static void plaintext_render(cmark_syntax_extension *extension,
+                             cmark_renderer *renderer, cmark_node *node,
+                             cmark_event_type ev_type, int options) {
+  renderer->out(renderer, node, "~", false, LITERAL);
+}
+
 cmark_syntax_extension *create_strikethrough_extension(void) {
   cmark_syntax_extension *ext = cmark_syntax_extension_new("strikethrough");
   cmark_llist *special_chars = NULL;
@@ -143,6 +149,7 @@ cmark_syntax_extension *create_strikethrough_extension(void) {
   cmark_syntax_extension_set_latex_render_func(ext, latex_render);
   cmark_syntax_extension_set_man_render_func(ext, man_render);
   cmark_syntax_extension_set_html_render_func(ext, html_render);
+  cmark_syntax_extension_set_plaintext_render_func(ext, plaintext_render);
   CMARK_NODE_STRIKETHROUGH = cmark_syntax_extension_add_node(1);
 
   cmark_syntax_extension_set_match_inline_func(ext, match);

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -102,4 +102,20 @@ aaa | bbb | ccc | ddd | eee
 fff | ggg | hhh | iii | jjj
       MD
   end
+
+  def test_plaintext
+    assert_equal(<<-HTML, CommonMarker.render_doc(<<-MD, :DEFAULT, %i[table strikethrough]).to_plaintext)
+Hello ~there~.
+
+| a |
+| --- |
+| b |
+    HTML
+Hello ~~there~~.
+
+| a |
+| - |
+| b |
+    MD
+  end
 end


### PR DESCRIPTION
Trying to render a document with a strikethrough node with the plaintext renderer asserts on `cmark-gfm < 0.28.3.gfm.14`.

/cc @TwP