### PR TITLE
bump to cmark-gfm 0.28.3.gfm.16

### DIFF
--- a/ext/commonmarker/cmark-gfm_version.h
+++ b/ext/commonmarker/cmark-gfm_version.h
@@ -1,7 +1,7 @@
 #ifndef CMARK_GFM_VERSION_H
 #define CMARK_GFM_VERSION_H
 
-#define CMARK_GFM_VERSION ((0 << 24) | (28 << 16) | (3 << 8) | 15)
-#define CMARK_GFM_VERSION_STRING "0.28.3.gfm.15"
+#define CMARK_GFM_VERSION ((0 << 24) | (28 << 16) | (3 << 8) | 16)
+#define CMARK_GFM_VERSION_STRING "0.28.3.gfm.16"
 
 #endif

--- a/ext/commonmarker/table.c
+++ b/ext/commonmarker/table.c
@@ -380,7 +380,8 @@ static int can_contain(cmark_syntax_extension *extension, cmark_node *node,
            child_type == CMARK_NODE_EMPH || child_type == CMARK_NODE_STRONG ||
            child_type == CMARK_NODE_LINK || child_type == CMARK_NODE_IMAGE ||
            child_type == CMARK_NODE_STRIKETHROUGH ||
-           child_type == CMARK_NODE_HTML_INLINE;
+           child_type == CMARK_NODE_HTML_INLINE ||
+           child_type == CMARK_NODE_FOOTNOTE_REFERENCE;
   }
   return false;
 }


### PR DESCRIPTION
Includes a fix which causes footnote references being rendered inside table cells.

/cc @gjtorikian @digitalmoksha