### PR TITLE
Latest upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ext/commonmarker/cmark-upstream"]
 	path = ext/commonmarker/cmark-upstream
-	url = https://github.com/github/cmark.git
+	url = https://github.com/github/cmark-gfm.git
 	ignore = dirty

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ CommonMarker accepts the same options that CMark does, as symbols. Note that the
 | `:GITHUB_PRE_LANG`               | Use GitHub-style `<pre lang>` for fenced code blocks.          |
 | `:HARDBREAKS`                    | Treat `\n` as hardbreaks (by adding `<br/>`).                  |
 | `:NOBREAKS`                      | Translate `\n` in the source to a single whitespace.           |
-| `:SAFE`                          | Suppress raw HTML and unsafe links.                            |
+| `:UNSAFE`                        | Allow raw HTML and unsafe links.                               |
 | `:SOURCEPOS`                     | Include source position in rendered HTML.                      |
 | `:TABLE_PREFER_STYLE_ATTRIBUTES` | Use `style` insted of `align` for table cells                  |
 | `:FULL_INFO_STRING`              | Include full info strings of code blocks in separate attribute |
@@ -177,7 +177,7 @@ The available extensions are:
 * `:table` - This provides support for tables.
 * `:strikethrough` - This provides support for strikethroughs.
 * `:autolink` - This provides support for automatically converting URLs to anchor tags.
-* `:tagfilter` - This strips out [several "unsafe" HTML tags](https://github.github.com/gfm/#disallowed-raw-html-extension-) from being used.
+* `:tagfilter` - This escapes [several "unsafe" HTML tags](https://github.github.com/gfm/#disallowed-raw-html-extension-), causing them to not have any effect.
 
 ## Developing locally
 

--- a/ext/commonmarker/cmark-gfm-core-extensions.h
+++ b/ext/commonmarker/cmark-gfm-core-extensions.h
@@ -18,6 +18,9 @@ uint16_t cmark_gfm_extensions_get_table_columns(cmark_node *node);
 CMARK_GFM_EXTENSIONS_EXPORT
 uint8_t *cmark_gfm_extensions_get_table_alignments(cmark_node *node);
 
+CMARK_GFM_EXTENSIONS_EXPORT
+int cmark_gfm_extensions_get_table_row_is_header(cmark_node *node);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ext/commonmarker/cmark-gfm-extension_api.h
+++ b/ext/commonmarker/cmark-gfm-extension_api.h
@@ -106,8 +106,6 @@ typedef struct cmark_plugin cmark_plugin;
  * with 'cmark_syntax_extension_set_private',
  * and optionally define a free function for this data.
  */
-typedef struct cmark_syntax_extension cmark_syntax_extension;
-
 typedef struct subject cmark_inline_parser;
 
 /** Exposed raw for now */
@@ -238,6 +236,9 @@ typedef int (*cmark_commonmark_escape_func) (cmark_syntax_extension *extension,
                                               cmark_node *node,
                                               int c);
 
+typedef const char* (*cmark_xml_attr_func) (cmark_syntax_extension *extension,
+                                            cmark_node *node);
+
 typedef void (*cmark_html_render_func) (cmark_syntax_extension *extension,
                                         struct cmark_html_renderer *renderer,
                                         cmark_node *node,
@@ -253,6 +254,10 @@ typedef cmark_node *(*cmark_postprocess_func) (cmark_syntax_extension *extension
                                                cmark_node *root);
 
 typedef int (*cmark_ispunct_func) (char c);
+
+typedef void (*cmark_opaque_alloc_func) (cmark_syntax_extension *extension,
+                                         cmark_mem *mem,
+                                         cmark_node *node);
 
 typedef void (*cmark_opaque_free_func) (cmark_syntax_extension *extension,
                                         cmark_mem *mem,
@@ -343,6 +348,12 @@ void cmark_syntax_extension_set_latex_render_func(cmark_syntax_extension *extens
 /** See the documentation for 'cmark_syntax_extension'
  */
 CMARK_GFM_EXPORT
+void cmark_syntax_extension_set_xml_attr_func(cmark_syntax_extension *extension,
+                                              cmark_xml_attr_func func);
+
+  /** See the documentation for 'cmark_syntax_extension'
+ */
+CMARK_GFM_EXPORT
 void cmark_syntax_extension_set_man_render_func(cmark_syntax_extension *extension,
                                                 cmark_common_render_func func);
 
@@ -381,6 +392,12 @@ void *cmark_syntax_extension_get_private(cmark_syntax_extension *extension);
 CMARK_GFM_EXPORT
 void cmark_syntax_extension_set_postprocess_func(cmark_syntax_extension *extension,
                                                  cmark_postprocess_func func);
+
+/** See the documentation for 'cmark_syntax_extension'
+ */
+CMARK_GFM_EXPORT
+void cmark_syntax_extension_set_opaque_alloc_func(cmark_syntax_extension *extension,
+                                                  cmark_opaque_alloc_func func);
 
 /** See the documentation for 'cmark_syntax_extension'
  */

--- a/ext/commonmarker/cmark-gfm.h
+++ b/ext/commonmarker/cmark-gfm.h
@@ -92,6 +92,7 @@ typedef enum {
 typedef struct cmark_node cmark_node;
 typedef struct cmark_parser cmark_parser;
 typedef struct cmark_iter cmark_iter;
+typedef struct cmark_syntax_extension cmark_syntax_extension;
 
 /**
  * ## Custom memory allocator support
@@ -186,6 +187,13 @@ CMARK_GFM_EXPORT cmark_node *cmark_node_new(cmark_node_type type);
  */
 CMARK_GFM_EXPORT cmark_node *cmark_node_new_with_mem(cmark_node_type type,
                                                  cmark_mem *mem);
+
+CMARK_GFM_EXPORT cmark_node *cmark_node_new_with_ext(cmark_node_type type,
+                                                cmark_syntax_extension *extension);
+
+CMARK_GFM_EXPORT cmark_node *cmark_node_new_with_mem_and_ext(cmark_node_type type,
+                                                cmark_mem *mem,
+                                                cmark_syntax_extension *extension);
 
 /** Frees the memory allocated for a node and any children.
  */
@@ -682,14 +690,6 @@ char *cmark_render_latex_with_mem(cmark_node *root, int options, int width, cmar
  */
 #define CMARK_OPT_HARDBREAKS (1 << 2)
 
-/** Suppress raw HTML and unsafe links (`javascript:`, `vbscript:`,
- * `file:`, and `data:`, except for `image/png`, `image/gif`,
- * `image/jpeg`, or `image/webp` mime types).  Raw HTML is replaced
- * by a placeholder HTML comment. Unsafe links are replaced by
- * empty strings.
- */
-#define CMARK_OPT_SAFE (1 << 3)
-
 /** Render `softbreak` elements as spaces.
  */
 #define CMARK_OPT_NOBREAKS (1 << 4)
@@ -737,6 +737,14 @@ char *cmark_render_latex_with_mem(cmark_node *root, int options, int width, cmar
  * a separate attribute.
  */
 #define CMARK_OPT_FULL_INFO_STRING (1 << 16)
+
+/** Allow raw HTML and unsafe links, `javascript:`, `vbscript:`, `file:`, and
+ * all `data:` URLs -- by default, only `image/png`, `image/gif`, `image/jpeg`,
+ * or `image/webp` mime types are allowed. Without this option, raw HTML is
+ * replaced by a placeholder HTML comment, and unsafe links are replaced by
+ * empty strings.
+ */
+#define CMARK_OPT_UNSAFE (1 << 17)
 
 /**
  * ## Version information

--- a/ext/commonmarker/cmark-gfm_version.h
+++ b/ext/commonmarker/cmark-gfm_version.h
@@ -1,7 +1,7 @@
 #ifndef CMARK_GFM_VERSION_H
 #define CMARK_GFM_VERSION_H
 
-#define CMARK_GFM_VERSION ((0 << 24) | (28 << 16) | (3 << 8) | 16)
-#define CMARK_GFM_VERSION_STRING "0.28.3.gfm.16"
+#define CMARK_GFM_VERSION ((0 << 24) | (28 << 16) | (3 << 8) | 18)
+#define CMARK_GFM_VERSION_STRING "0.28.3.gfm.18"
 
 #endif

--- a/ext/commonmarker/commonmark.c
+++ b/ext/commonmarker/commonmark.c
@@ -168,6 +168,7 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
   int list_number;
   cmark_delim_type list_delim;
   int numticks;
+  bool extra_spaces;
   int i;
   bool entering = (ev_type == CMARK_EVENT_ENTER);
   const char *info, *code, *title;
@@ -369,14 +370,17 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
     code = cmark_node_get_literal(node);
     code_len = strlen(code);
     numticks = shortest_unused_backtick_sequence(code);
+    extra_spaces = code_len == 0 ||
+	    code[0] == '`' || code[code_len - 1] == '`' ||
+	    code[0] == ' ' || code[code_len - 1] == ' ';
     for (i = 0; i < numticks; i++) {
       LIT("`");
     }
-    if (code_len == 0 || code[0] == '`') {
+    if (extra_spaces) {
       LIT(" ");
     }
     OUT(cmark_node_get_literal(node), allow_wrap, LITERAL);
-    if (code_len == 0 || code[code_len - 1] == '`') {
+    if (extra_spaces) {
       LIT(" ");
     }
     for (i = 0; i < numticks; i++) {

--- a/ext/commonmarker/html.c
+++ b/ext/commonmarker/html.c
@@ -227,7 +227,7 @@ static int S_render_node(cmark_html_renderer *renderer, cmark_node *node,
 
   case CMARK_NODE_HTML_BLOCK:
     cmark_html_render_cr(html);
-    if (options & CMARK_OPT_SAFE) {
+    if (!(options & CMARK_OPT_UNSAFE)) {
       cmark_strbuf_puts(html, "<!-- raw HTML omitted -->");
     } else if (renderer->filter_extensions) {
       filter_html_block(renderer, node->as.literal.data, node->as.literal.len);
@@ -305,7 +305,7 @@ static int S_render_node(cmark_html_renderer *renderer, cmark_node *node,
     break;
 
   case CMARK_NODE_HTML_INLINE:
-    if (options & CMARK_OPT_SAFE) {
+    if (!(options & CMARK_OPT_UNSAFE)) {
       cmark_strbuf_puts(html, "<!-- raw HTML omitted -->");
     } else {
       filtered = false;
@@ -354,7 +354,7 @@ static int S_render_node(cmark_html_renderer *renderer, cmark_node *node,
   case CMARK_NODE_LINK:
     if (entering) {
       cmark_strbuf_puts(html, "<a href=\"");
-      if (!((options & CMARK_OPT_SAFE) &&
+      if (!(!(options & CMARK_OPT_UNSAFE) &&
             scan_dangerous_url(&node->as.link.url, 0))) {
         houdini_escape_href(html, node->as.link.url.data,
                             node->as.link.url.len);
@@ -372,7 +372,7 @@ static int S_render_node(cmark_html_renderer *renderer, cmark_node *node,
   case CMARK_NODE_IMAGE:
     if (entering) {
       cmark_strbuf_puts(html, "<img src=\"");
-      if (!((options & CMARK_OPT_SAFE) &&
+      if (!(!(options & CMARK_OPT_UNSAFE) &&
             scan_dangerous_url(&node->as.link.url, 0))) {
         houdini_escape_href(html, node->as.link.url.data,
                             node->as.link.url.len);

--- a/ext/commonmarker/inlines.c
+++ b/ext/commonmarker/inlines.c
@@ -321,6 +321,37 @@ static bufsize_t scan_to_closing_backticks(subject *subj,
   return 0;
 }
 
+// Destructively modify string, converting newlines to
+// spaces, then removing a single leading + trailing space.
+static void S_normalize_code(cmark_strbuf *s) {
+  bufsize_t r, w;
+
+  for (r = 0, w = 0; r < s->size; ++r) {
+    switch (s->ptr[r]) {
+    case '\r':
+      if (s->ptr[r + 1] != '\n') {
+	s->ptr[w++] = ' ';
+      }
+      break;
+    case '\n':
+      s->ptr[w++] = ' ';
+      break;
+    default:
+      s->ptr[w++] = s->ptr[r];
+    }
+  }
+
+  // begins and ends with space?
+  if (s->ptr[0] == ' ' && s->ptr[w - 1] == ' ') {
+    cmark_strbuf_drop(s, 1);
+    cmark_strbuf_truncate(s, w - 2);
+  } else {
+    cmark_strbuf_truncate(s, w);
+  }
+
+}
+
+
 // Parse backtick code section or raw backticks, return an inline.
 // Assumes that the subject has a backtick at the current position.
 static cmark_node *handle_backticks(subject *subj, int options) {
@@ -336,14 +367,14 @@ static cmark_node *handle_backticks(subject *subj, int options) {
 
     cmark_strbuf_set(&buf, subj->input.data + startpos,
                      endpos - startpos - openticks.len);
-    cmark_strbuf_trim(&buf);
-    cmark_strbuf_normalize_whitespace(&buf);
+    S_normalize_code(&buf);
 
     cmark_node *node = make_code(subj, startpos, endpos - openticks.len - 1, cmark_chunk_buf_detach(&buf));
     adjust_subj_node_newlines(subj, node, endpos - startpos, openticks.len, options);
     return node;
   }
 }
+
 
 // Scan ***, **, or * and return number scanned, or 0.
 // Advances position.
@@ -1410,7 +1441,7 @@ bufsize_t cmark_parse_reference_inline(cmark_mem *mem, cmark_chunk *input,
   // parse optional link_title
   beforetitle = subj.pos;
   spnl(&subj);
-  matchlen = scan_link_title(&subj.input, subj.pos);
+  matchlen = subj.pos == beforetitle ? 0 : scan_link_title(&subj.input, subj.pos);
   if (matchlen) {
     title = cmark_chunk_dup(&subj.input, subj.pos, matchlen);
     subj.pos += matchlen;

--- a/ext/commonmarker/strikethrough.c
+++ b/ext/commonmarker/strikethrough.c
@@ -28,7 +28,7 @@ static cmark_node *match(cmark_syntax_extension *self, cmark_parser *parser,
   res->start_column = cmark_inline_parser_get_column(inline_parser) - delims;
 
   if ((left_flanking || right_flanking) &&
-      (!(parser->options & CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE) || delims == 2)) {
+      (delims == 2 || (!(parser->options & CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE) && delims == 1))) {
     cmark_inline_parser_push_delimiter(inline_parser, character, left_flanking,
                                        right_flanking, res);
   }
@@ -45,6 +45,9 @@ static delimiter *insert(cmark_syntax_extension *self, cmark_parser *parser,
   delimiter *res = closer->next;
 
   strikethrough = opener->inl_text;
+
+  if (opener->inl_text->as.literal.len != closer->inl_text->as.literal.len)
+    goto done;
 
   if (!cmark_node_set_type(strikethrough, CMARK_NODE_STRIKETHROUGH))
     goto done;

--- a/ext/commonmarker/syntax_extension.c
+++ b/ext/commonmarker/syntax_extension.c
@@ -97,6 +97,11 @@ void cmark_syntax_extension_set_latex_render_func(cmark_syntax_extension *extens
   extension->latex_render_func = func;
 }
 
+void cmark_syntax_extension_set_xml_attr_func(cmark_syntax_extension *extension,
+                                              cmark_xml_attr_func func) {
+  extension->xml_attr_func = func;
+}
+
 void cmark_syntax_extension_set_man_render_func(cmark_syntax_extension *extension,
                                                 cmark_common_render_func func) {
   extension->man_render_func = func;
@@ -126,6 +131,11 @@ void cmark_syntax_extension_set_private(cmark_syntax_extension *extension,
 
 void *cmark_syntax_extension_get_private(cmark_syntax_extension *extension) {
     return extension->priv;
+}
+
+void cmark_syntax_extension_set_opaque_alloc_func(cmark_syntax_extension *extension,
+                                                  cmark_opaque_alloc_func func) {
+  extension->opaque_alloc_func = func;
 }
 
 void cmark_syntax_extension_set_opaque_free_func(cmark_syntax_extension *extension,

--- a/ext/commonmarker/syntax_extension.h
+++ b/ext/commonmarker/syntax_extension.h
@@ -21,10 +21,12 @@ struct cmark_syntax_extension {
   cmark_common_render_func        commonmark_render_func;
   cmark_common_render_func        plaintext_render_func;
   cmark_common_render_func        latex_render_func;
+  cmark_xml_attr_func             xml_attr_func;
   cmark_common_render_func        man_render_func;
   cmark_html_render_func          html_render_func;
   cmark_html_filter_func          html_filter_func;
   cmark_postprocess_func          postprocess_func;
+  cmark_opaque_alloc_func         opaque_alloc_func;
   cmark_opaque_free_func          opaque_free_func;
   cmark_commonmark_escape_func    commonmark_escape_func;
 };

--- a/ext/commonmarker/table.c
+++ b/ext/commonmarker/table.c
@@ -9,6 +9,7 @@
 #include "ext_scanners.h"
 #include "strikethrough.h"
 #include "table.h"
+#include "cmark-gfm-core-extensions.h"
 
 cmark_node_type CMARK_NODE_TABLE, CMARK_NODE_TABLE_ROW,
     CMARK_NODE_TABLE_CELL;
@@ -488,6 +489,27 @@ static void latex_render(cmark_syntax_extension *extension,
   }
 }
 
+static const char *xml_attr(cmark_syntax_extension *extension,
+                            cmark_node *node) {
+  if (node->type == CMARK_NODE_TABLE_CELL) {
+    if (cmark_gfm_extensions_get_table_row_is_header(node->parent)) {
+      uint8_t *alignments = get_table_alignments(node->parent->parent);
+      int i = 0;
+      cmark_node *n;
+      for (n = node->parent->first_child; n; n = n->next, ++i)
+        if (n == node)
+          break;
+      switch (alignments[i]) {
+      case 'l': return " align=\"left\"";
+      case 'c': return " align=\"center\"";
+      case 'r': return " align=\"right\"";
+      }
+    }
+  }
+
+  return NULL;
+}
+
 static void man_render(cmark_syntax_extension *extension,
                        cmark_renderer *renderer, cmark_node *node,
                        cmark_event_type ev_type, int options) {
@@ -648,6 +670,16 @@ static void html_render(cmark_syntax_extension *extension,
   }
 }
 
+static void opaque_alloc(cmark_syntax_extension *self, cmark_mem *mem, cmark_node *node) {
+  if (node->type == CMARK_NODE_TABLE) {
+    node->as.opaque = mem->calloc(1, sizeof(node_table));
+  } else if (node->type == CMARK_NODE_TABLE_ROW) {
+    node->as.opaque = mem->calloc(1, sizeof(node_table_row));
+  } else if (node->type == CMARK_NODE_TABLE_CELL) {
+    node->as.opaque = mem->calloc(1, sizeof(node_cell));
+  }
+}
+
 static void opaque_free(cmark_syntax_extension *self, cmark_mem *mem, cmark_node *node) {
   if (node->type == CMARK_NODE_TABLE) {
     free_node_table(mem, node->as.opaque);
@@ -675,8 +707,10 @@ cmark_syntax_extension *create_table_extension(void) {
   cmark_syntax_extension_set_commonmark_render_func(self, commonmark_render);
   cmark_syntax_extension_set_plaintext_render_func(self, commonmark_render);
   cmark_syntax_extension_set_latex_render_func(self, latex_render);
+  cmark_syntax_extension_set_xml_attr_func(self, xml_attr);
   cmark_syntax_extension_set_man_render_func(self, man_render);
   cmark_syntax_extension_set_html_render_func(self, html_render);
+  cmark_syntax_extension_set_opaque_alloc_func(self, opaque_alloc);
   cmark_syntax_extension_set_opaque_free_func(self, opaque_free);
   cmark_syntax_extension_set_commonmark_escape_func(self, escape);
   CMARK_NODE_TABLE = cmark_syntax_extension_add_node(0);
@@ -698,4 +732,31 @@ uint8_t *cmark_gfm_extensions_get_table_alignments(cmark_node *node) {
     return 0;
 
   return ((node_table *)node->as.opaque)->alignments;
+}
+
+int cmark_gfm_extensions_set_table_columns(cmark_node *node, uint16_t n_columns) {
+  return set_n_table_columns(node, n_columns);
+}
+
+int cmark_gfm_extensions_set_table_alignments(cmark_node *node, uint16_t ncols, uint8_t *alignments) {
+  uint8_t *a = (uint8_t *)cmark_node_mem(node)->calloc(1, ncols);
+  memcpy(a, alignments, ncols);
+  return set_table_alignments(node, a);
+}
+
+int cmark_gfm_extensions_get_table_row_is_header(cmark_node *node)
+{
+  if (!node || node->type != CMARK_NODE_TABLE_ROW)
+    return 0;
+
+  return ((node_table_row *)node->as.opaque)->is_header;
+}
+
+int cmark_gfm_extensions_set_table_row_is_header(cmark_node *node, int is_header)
+{
+  if (!node || node->type != CMARK_NODE_TABLE_ROW)
+    return 0;
+
+  ((node_table_row *)node->as.opaque)->is_header = (is_header != 0);
+  return 1;
 }

--- a/ext/commonmarker/xml.c
+++ b/ext/commonmarker/xml.c
@@ -8,6 +8,7 @@
 #include "node.h"
 #include "buffer.h"
 #include "houdini.h"
+#include "syntax_extension.h"
 
 #define BUFFER_SIZE 100
 
@@ -50,6 +51,12 @@ static int S_render_node(cmark_node *node, cmark_event_type ev_type,
       cmark_strbuf_puts(xml, buffer);
     }
 
+    if (node->extension && node->extension->xml_attr_func) {
+      const char* r = node->extension->xml_attr_func(node->extension, node);
+      if (r != NULL)
+        cmark_strbuf_puts(xml, r);
+    }
+
     literal = false;
 
     switch (node->type) {
@@ -60,7 +67,7 @@ static int S_render_node(cmark_node *node, cmark_event_type ev_type,
     case CMARK_NODE_CODE:
     case CMARK_NODE_HTML_BLOCK:
     case CMARK_NODE_HTML_INLINE:
-      cmark_strbuf_puts(xml, ">");
+      cmark_strbuf_puts(xml, " xml:space=\"preserve\">");
       escape_xml(xml, node->as.literal.data, node->as.literal.len);
       cmark_strbuf_puts(xml, "</");
       cmark_strbuf_puts(xml, cmark_node_get_type_string(node));
@@ -100,7 +107,7 @@ static int S_render_node(cmark_node *node, cmark_event_type ev_type,
         escape_xml(xml, node->as.code.info.data, node->as.code.info.len);
         cmark_strbuf_putc(xml, '"');
       }
-      cmark_strbuf_puts(xml, ">");
+      cmark_strbuf_puts(xml, " xml:space=\"preserve\">");
       escape_xml(xml, node->as.code.literal.data, node->as.code.literal.len);
       cmark_strbuf_puts(xml, "</");
       cmark_strbuf_puts(xml, cmark_node_get_type_string(node));

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -19,7 +19,7 @@ module CommonMarker
       define :DEFAULT, 0
       define :SOURCEPOS, (1 << 1)
       define :HARDBREAKS, (1 << 2)
-      define :SAFE, (1 << 3)
+      define :UNSAFE, (1 << 17)
       define :NOBREAKS, (1 << 4)
       define :GITHUB_PRE_LANG, (1 << 11)
       define :TABLE_PREFER_STYLE_ATTRIBUTES, (1 << 15)

--- a/lib/commonmarker/renderer/html_renderer.rb
+++ b/lib/commonmarker/renderer/html_renderer.rb
@@ -103,19 +103,19 @@ module CommonMarker
 
     def html(node)
       block do
-        if option_enabled?(:SAFE)
-          out('<!-- raw HTML omitted -->')
-        else
+        if option_enabled?(:UNSAFE)
           out(tagfilter(node.string_content))
+        else
+          out('<!-- raw HTML omitted -->')
         end
       end
     end
 
     def inline_html(node)
-      if option_enabled?(:SAFE)
-        out('<!-- raw HTML omitted -->')
-      else
+      if option_enabled?(:UNSAFE)
         out(tagfilter(node.string_content))
+      else
+        out('<!-- raw HTML omitted -->')
       end
     end
 

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -73,7 +73,7 @@ Another extension:
 
   def test_comments_are_kept_as_expected
     assert_equal "<!--hello--> <blah> &lt;xmp>\n",
-      CommonMarker.render_html("<!--hello--> <blah> <xmp>\n", :DEFAULT, %i[tagfilter])
+      CommonMarker.render_html("<!--hello--> <blah> <xmp>\n", :UNSAFE, %i[tagfilter])
   end
 
   def test_table_prefer_style_attributes

--- a/test/test_spec.rb
+++ b/test/test_spec.rb
@@ -9,18 +9,18 @@ class TestSpec < Minitest::Test
     doc = CommonMarker.render_doc(testcase[:markdown], :DEFAULT, testcase[:extensions])
 
     define_method("test_to_html_example_#{testcase[:example]}") do
-      actual = doc.to_html(:DEFAULT, testcase[:extensions]).rstrip
+      actual = doc.to_html(:UNSAFE, testcase[:extensions]).rstrip
       assert_equal testcase[:html], actual, testcase[:markdown]
     end
 
     define_method("test_html_renderer_example_#{testcase[:example]}") do
-      actual = HtmlRenderer.new(extensions: testcase[:extensions]).render(doc).rstrip
+      actual = HtmlRenderer.new(options: :UNSAFE, extensions: testcase[:extensions]).render(doc).rstrip
       assert_equal testcase[:html], actual, testcase[:markdown]
     end
 
     define_method("test_sourcepos_example_#{testcase[:example]}") do
-      lhs = doc.to_html(:SOURCEPOS, testcase[:extensions]).rstrip
-      rhs = HtmlRenderer.new(options: :SOURCEPOS, extensions: testcase[:extensions]).render(doc).rstrip
+      lhs = doc.to_html([:UNSAFE, :SOURCEPOS], testcase[:extensions]).rstrip
+      rhs = HtmlRenderer.new(options: [:UNSAFE, :SOURCEPOS], extensions: testcase[:extensions]).render(doc).rstrip
       assert_equal lhs, rhs, testcase[:markdown]
     end
   end


### PR DESCRIPTION
Pulls in https://github.com/github/cmark-gfm/pull/123, defaulting to safe operation.

/cc @gjtorikian for your consideration. This change requires downstream users to use `:UNSAFE` to get the effect that `:DEFAULT` previously would.

Alternatively, we could insulate users of commonmarker from the cmark-gfm change by sending `CMARK_OPT_UNSAFE` to the library _unless_ `:SAFE` was provided -- it depends on how much we'd be concerned about users updating and complaining, I think, but I do believe defaulting to non-XSSable output is the better option.