### PR TITLE
GitHub is https by default

### DIFF
--- a/commonmarker.gemspec
+++ b/commonmarker.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary = 'CommonMark parser and renderer. Written in C, wrapped in Ruby.'
   s.description = 'A fast, safe, extensible parser for CommonMark. This wraps the official libcmark library.'
   s.authors       = ['Garen Torikian', 'Ashe Connor']
-  s.homepage = 'http://github.com/gjtorikian/commonmarker'
+  s.homepage = 'https://github.com/gjtorikian/commonmarker'
   s.license = 'MIT'
   s.required_ruby_version = '>= 2.0.0'
 


### PR DESCRIPTION
This reduces unneeded redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/commonmarker or some tools that uses the gem metadata.