### PR TITLE
Fixes up whitespace problems introduced in #87

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ CommonMarker accepts the same options that CMark does, as symbols. Note that the
 | Name                          | Description
 | ----------------------------- | -----------
 | `:DEFAULT`                    | The default parsing system.
-| `:UNSAFE`                        | Allow raw/custom HTML and unsafe links.                               |
+| `:UNSAFE`                     | Allow raw/custom HTML and unsafe links.
 | `:FOOTNOTES`                  | Parse footnotes.
 | `:LIBERAL_HTML_TAG`           | Support liberal parsing of inline HTML tags.
 | `:SMART`                      | Use smart punctuation (curly quotes, etc.).
@@ -144,10 +144,10 @@ CommonMarker accepts the same options that CMark does, as symbols. Note that the
 | Name                             | Description                                                    |
 | ------------------               | -----------                                                    |
 | `:DEFAULT`                       | The default rendering system.                                  |
-| `:UNSAFE`                        | Allow raw/custom HTML and unsafe links.   
+| `:UNSAFE`                        | Allow raw/custom HTML and unsafe links.                        |
 | `:GITHUB_PRE_LANG`               | Use GitHub-style `<pre lang>` for fenced code blocks.          |
 | `:HARDBREAKS`                    | Treat `\n` as hardbreaks (by adding `<br/>`).                  |
-| `:NOBREAKS`                      | Translate `\n` in the source to a single whitespace.           |                            |
+| `:NOBREAKS`                      | Translate `\n` in the source to a single whitespace.           |
 | `:SOURCEPOS`                     | Include source position in rendered HTML.                      |
 | `:TABLE_PREFER_STYLE_ATTRIBUTES` | Use `style` insted of `align` for table cells                  |
 | `:FULL_INFO_STRING`              | Include full info strings of code blocks in separate attribute |


### PR DESCRIPTION
I just noticed a couple whitespace issues in the README when looking over the transition from 0.18.1 to 0.18.2, and #87 had inadvertently added a couple of inconsistencies.