### PR TITLE
tasklist state inverted

### DIFF
--- a/ext/commonmarker/tasklist.c
+++ b/ext/commonmarker/tasklist.c
@@ -17,7 +17,7 @@ char *cmark_gfm_extensions_get_tasklist_state(cmark_node *node) {
   if (!node || ((int)node->as.opaque != CMARK_TASKLIST_CHECKED && (int)node->as.opaque != CMARK_TASKLIST_NOCHECKED))
     return 0;
 
-  if ((int)node->as.opaque != CMARK_TASKLIST_CHECKED) {
+  if ((int)node->as.opaque == CMARK_TASKLIST_CHECKED) {
     return "checked";
   }
   else {
@@ -74,7 +74,8 @@ static cmark_node *open_tasklist_item(cmark_syntax_extension *self,
   cmark_node_set_syntax_extension(parent_container, self);
   cmark_parser_advance_offset(parser, (char *)input, 3, false);
 
-  if (strstr((char*)input, "[x]")) {
+  // Either an upper or lower case X means the task is completed.
+  if (strstr((char*)input, "[x]") || strstr((char*)input, "[X]")) {
     parent_container->as.opaque = (void *)CMARK_TASKLIST_CHECKED;
   } else {
     parent_container->as.opaque = (void *)CMARK_TASKLIST_NOCHECKED;

--- a/lib/commonmarker/renderer.rb
+++ b/lib/commonmarker/renderer.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-# rubocop:disable Standard/RailsViewRenderLiteral
-# rubocop:disable Standard/RailsControllerRenderLiteral
 
 require 'set'
 require 'stringio'

--- a/lib/commonmarker/renderer/html_renderer.rb
+++ b/lib/commonmarker/renderer/html_renderer.rb
@@ -72,9 +72,9 @@ module CommonMarker
     def tasklist(node)
       return '' unless tasklist?(node)
       state = if checked?(node)
-        'disabled=""'
-      else
         'checked="" disabled=""'
+      else
+        'disabled=""'
       end
       return "><input type=\"checkbox\" #{state} /"
     end

--- a/test/test_tasklists.rb
+++ b/test/test_tasklists.rb
@@ -27,7 +27,7 @@ MD
 
   def test_tasklist_state
     list = @doc.first_child
-    assert_equal "checked", list.first_child.tasklist_state
-    assert_equal "unchecked", list.first_child.next.tasklist_state
+    assert_equal 'checked', list.first_child.tasklist_state
+    assert_equal 'unchecked', list.first_child.next.tasklist_state
   end
 end

--- a/test/test_tasklists.rb
+++ b/test/test_tasklists.rb
@@ -24,4 +24,10 @@ MD
   def test_html_renderer
     assert_equal @expected, CommonMarker::HtmlRenderer.new.render(@doc)
   end
+
+  def test_tasklist_state
+    list = @doc.first_child
+    assert_equal "checked", list.first_child.tasklist_state
+    assert_equal "unchecked", list.first_child.next.tasklist_state
+  end
 end


### PR DESCRIPTION
`tasklist_state` is inverted; fix this from upstream. See https://github.com/github/cmark-gfm/pull/142.