### PR TITLE
Add command line input for parse and render options

### DIFF
--- a/bin/commonmarker
+++ b/bin/commonmarker
@@ -21,16 +21,16 @@ def parse_options
   options.active_render_options = [:DEFAULT]
 
   option_parser = OptionParser.new do |opts|
-    opts.banner = 'Usage: commonmarker [--html-renderer] [--list-extensions] [--extension=EXTENSION]'
-    opts.separator '                    [--list-parse-options] [--parse-option=OPTION]'
-    opts.separator '                    [--list-render-options] [--render-option=OPTION]'
+    opts.banner = 'Usage: commonmarker [--html-renderer] [--extension=EXTENSION]'
+    opts.separator '                    [--parse-option=OPTION]'
+    opts.separator '                    [--render-option=OPTION]'
     opts.separator '                    [FILE..]'
     opts.separator ''
     opts.separator 'Convert one or more CommonMark files to HTML and write to standard output.'
     opts.separator 'If no FILE argument is provided, text will be read from STDIN.'
     opts.separator ''
 
-    opts.on('--extension=EXTENSION', Array, 'Use EXTENSION for parsing and HTML output unless --html-renderer is specified') do |values|
+    opts.on('--extension=EXTENSION', Array, 'Use EXTENSION for parsing and HTML output (unless --html-renderer is specified)') do |values|
       values.each do |value|
         if extensions.include?(value)
           options.active_extensions << value.to_sym
@@ -42,6 +42,12 @@ def parse_options
 
     opts.on('-h', '--help', 'Prints this help') do
       puts opts
+      puts
+      puts "Available extentions: #{extensions.join(', ')}"
+      puts "Available parse options: #{parse_options.keys.join(', ')}"
+      puts "Available render options: #{render_options.keys.join(', ')}"
+      puts
+      puts 'See the README for more information on these.'
       exit
     end
 
@@ -49,22 +55,7 @@ def parse_options
       options.renderer = true
     end
 
-    opts.on('--list-extensions', 'List the supported extensions') do
-      puts extensions
-      exit
-    end
-
-    opts.on('--list-parse-options', 'List the supported parsing options') do
-      puts parse_options.keys
-      exit
-    end
-
-    opts.on('--list-render-options', 'List the supported rendering options') do
-      puts render_options.keys
-      exit
-    end
-
-    opts.on('--parse-option=OPTION', Array, 'OPTION will be passed during parsing') do |values|
+    opts.on('--parse-option=OPTION', Array, 'OPTION passed during parsing') do |values|
       values.each do |value|
         if parse_options.key?(value.to_sym)
           options.active_parse_options << value.to_sym
@@ -74,7 +65,7 @@ def parse_options
       end
     end
 
-    opts.on('--render-option=OPTION', Array, 'OPTION will be passed during rendering') do |values|
+    opts.on('--render-option=OPTION', Array, 'OPTION passed during rendering') do |values|
       values.each do |value|
         if render_options.key?(value.to_sym)
           options.active_render_options << value.to_sym

--- a/bin/commonmarker
+++ b/bin/commonmarker
@@ -1,94 +1,101 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Usage: commonmarker [--html-renderer] [--list-extensions] [--extension=EXTENSION]
-#                     [--list-parse-options] [--parse-option=OPTION]
-#                     [--list-render-options] [--render-option=OPTION]
-#                     [FILE..]
-# Convert one or more CommonMark files to HTML and write to standard output.
-# If no FILE argument is provided, text will be read from STDIN.
-# With --html-renderer, use the HtmlRenderer renderer rather than the native C
-# renderer.
-# With --extension=EXTENSION, EXTENSION will be used for parsing, and HTML
-# output unless --html-renderer is specified.
-# With --parse-option=OPTION, OPTION will be passed during parsing.
-# With --render-option=OPTION, OPTION will be passed during rendering.
-
-if ARGV.include?('--help') or ARGV.include?('-h')
-  File.read(__FILE__).split("\n")[2..-1].grep(/^# /).each do |line|
-    puts line[2..-1]
-  end
-  exit 0
-end
+require 'optparse'
+require 'ostruct'
 
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'commonmarker'
 
-if ARGV.include?('--version') or ARGV.include?('-v')
-  puts "commonmarker #{CommonMarker::VERSION}"
-  exit 0
-end
-
 root = File.expand_path('../../', __FILE__)
 $:.unshift File.expand_path('lib', root)
 
-extensions = CommonMarker.extensions
-active_extensions = []
+def parse_options
+  options = OpenStruct.new
+  extensions = CommonMarker.extensions
+  parse_options = CommonMarker::Config::Parse
+  render_options = CommonMarker::Config::Render
 
-parse_options = CommonMarker::Config::Parse
-active_parse_options = [:DEFAULT]
+  options.active_extensions = []
+  options.active_parse_options = [:DEFAULT]
+  options.active_render_options = [:DEFAULT]
 
-render_options = CommonMarker::Config::Render
-active_render_options = [:DEFAULT]
+  option_parser = OptionParser.new do |opts|
+    opts.banner  = 'Usage: commonmarker [--html-renderer] [--list-extensions] [--extension=EXTENSION]'
+    opts.separator '                    [--list-parse-options] [--parse-option=OPTION]'
+    opts.separator '                    [--list-render-options] [--render-option=OPTION]'
+    opts.separator '                    [FILE..]'
+    opts.separator ''
+    opts.separator 'Convert one or more CommonMark files to HTML and write to standard output.'
+    opts.separator 'If no FILE argument is provided, text will be read from STDIN.'
+    opts.separator ''
 
-renderer = nil
-ARGV.delete_if do |arg|
-  if arg =~ /^--html-renderer$/
-    renderer = true
-    true
-  elsif arg =~ /^--list-extensions$/
-    puts extensions
-    exit 0
-  elsif arg =~ /^--extension=(.+)$/
-    if extensions.include?($1)
-      active_extensions << $1.intern
-    else
-      STDERR.puts "extension #$1 not found"
-      exit 1
+    opts.on('--extension=EXTENSION', 'Use EXTENSION for parsing and HTML output unless --html-renderer is specified') do |value|
+      if extensions.include?(value)
+        options.active_extensions << value.to_sym
+      else
+        abort("extension '#{value}' not found")
+      end
     end
-    true
-  elsif arg =~ /^--list-parse-options$/
-    puts parse_options.keys
-    exit 0
-  elsif arg =~ /^--parse-option=(.+)$/
-    if parse_options.key?($1.to_sym)
-      active_parse_options << $1.to_sym
-    else
-      STDERR.puts "parse-option #$1 not found"
-      exit 1
+
+    opts.on('-h', '--help', 'Prints this help') do
+      puts opts
+      exit
     end
-    true
-  elsif arg =~ /^--list-render-options$/
-    puts render_options.keys
-    exit 0
-  elsif arg =~ /^--render-option=(.+)$/
-    if render_options.key?($1.to_sym)
-      active_render_options << $1.to_sym
-    else
-      STDERR.puts "render-option #$1 not found"
-      exit 1
+
+    opts.on('--html-renderer', 'Use the HtmlRenderer renderer rather than the native C renderer') do
+      options.renderer = true
     end
-    true
-  else
-    false
+
+    opts.on('--list-extensions', 'List the supported extensions') do
+      puts extensions
+      exit
+    end
+
+    opts.on('--list-parse-options', 'List the supported parsing options') do
+      puts parse_options.keys
+      exit
+    end
+
+    opts.on('--list-render-options', 'List the supported rendering options') do
+      puts render_options.keys
+      exit
+    end
+
+    opts.on('--parse-option=OPTION', 'OPTION will be passed during parsing') do |value|
+      if parse_options.key?(value.to_sym)
+        options.active_parse_options << value.to_sym
+      else
+        abort("parse-option '#{value}' not found")
+      end
+    end
+
+    opts.on('--render-option=OPTION', 'OPTION will be passed during rendering') do |value|
+      if render_options.key?(value.to_sym)
+        options.active_render_options << value.to_sym
+      else
+        abort("render-option '#{value}' not found")
+      end
+    end
+
+    opts.on("-v", "--version", 'Version information') do
+      puts "commonmarker #{CommonMarker::VERSION}"
+      exit
+    end
   end
+
+  option_parser.parse!
+
+  return options
 end
 
-doc = CommonMarker.render_doc(ARGF.read, active_parse_options, active_extensions)
+options = parse_options
 
-if renderer
-  renderer = CommonMarker::HtmlRenderer.new(extensions: active_extensions)
-  STDOUT.write(active_render_options.render(doc))
+doc = CommonMarker.render_doc(ARGF.read, options.active_parse_options, options.active_extensions)
+
+if options.renderer
+  renderer = CommonMarker::HtmlRenderer.new(extensions: options.active_extensions)
+  STDOUT.write(renderer.render(doc))
 else
-  STDOUT.write(doc.to_html(active_render_options, active_extensions))
+  STDOUT.write(doc.to_html(options.active_render_options, options.active_extensions))
 end

--- a/bin/commonmarker
+++ b/bin/commonmarker
@@ -1,15 +1,21 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Usage: commonmarker [--html-renderer] [--list-extensions] [--extension=EXTENSION] [FILE..]
+# Usage: commonmarker [--html-renderer] [--list-extensions] [--extension=EXTENSION]
+#                     [--list-parse-options] [--parse-option=OPTION]
+#                     [--list-render-options] [--render-option=OPTION]
+#                     [FILE..]
 # Convert one or more CommonMark files to HTML and write to standard output.
 # If no FILE argument is provided, text will be read from STDIN.
 # With --html-renderer, use the HtmlRenderer renderer rather than the native C
 # renderer.
 # With --extension=EXTENSION, EXTENSION will be used for parsing, and HTML
 # output unless --html-renderer is specified.
+# With --parse-option=OPTION, OPTION will be passed during parsing.
+# With --render-option=OPTION, OPTION will be passed during rendering.
+
 if ARGV.include?('--help') or ARGV.include?('-h')
-  File.read(__FILE__).split("\n").grep(/^# /).each do |line|
+  File.read(__FILE__).split("\n")[2..-1].grep(/^# /).each do |line|
     puts line[2..-1]
   end
   exit 0
@@ -29,6 +35,12 @@ $:.unshift File.expand_path('lib', root)
 extensions = CommonMarker.extensions
 active_extensions = []
 
+parse_options = CommonMarker::Config::Parse
+active_parse_options = [:DEFAULT]
+
+render_options = CommonMarker::Config::Render
+active_render_options = [:DEFAULT]
+
 renderer = nil
 ARGV.delete_if do |arg|
   if arg =~ /^--html-renderer$/
@@ -45,16 +57,38 @@ ARGV.delete_if do |arg|
       exit 1
     end
     true
+  elsif arg =~ /^--list-parse-options$/
+    puts parse_options.keys
+    exit 0
+  elsif arg =~ /^--parse-option=(.+)$/
+    if parse_options.key?($1.to_sym)
+      active_parse_options << $1.to_sym
+    else
+      STDERR.puts "parse-option #$1 not found"
+      exit 1
+    end
+    true
+  elsif arg =~ /^--list-render-options$/
+    puts render_options.keys
+    exit 0
+  elsif arg =~ /^--render-option=(.+)$/
+    if render_options.key?($1.to_sym)
+      active_render_options << $1.to_sym
+    else
+      STDERR.puts "render-option #$1 not found"
+      exit 1
+    end
+    true
   else
     false
   end
 end
 
-doc = CommonMarker.render_doc(ARGF.read, :DEFAULT, active_extensions)
+doc = CommonMarker.render_doc(ARGF.read, active_parse_options, active_extensions)
 
 if renderer
   renderer = CommonMarker::HtmlRenderer.new(extensions: active_extensions)
-  STDOUT.write(renderer.render(doc))
+  STDOUT.write(active_render_options.render(doc))
 else
-  STDOUT.write(doc.to_html(:DEFAULT, active_extensions))
+  STDOUT.write(doc.to_html(active_render_options, active_extensions))
 end

--- a/bin/commonmarker
+++ b/bin/commonmarker
@@ -7,8 +7,8 @@ require 'ostruct'
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'commonmarker'
 
-root = File.expand_path('../../', __FILE__)
-$:.unshift File.expand_path('lib', root)
+root = File.expand_path('..', __dir__)
+$LOAD_PATH.unshift File.expand_path('lib', root)
 
 def parse_options
   options = OpenStruct.new
@@ -21,7 +21,7 @@ def parse_options
   options.active_render_options = [:DEFAULT]
 
   option_parser = OptionParser.new do |opts|
-    opts.banner  = 'Usage: commonmarker [--html-renderer] [--list-extensions] [--extension=EXTENSION]'
+    opts.banner = 'Usage: commonmarker [--html-renderer] [--list-extensions] [--extension=EXTENSION]'
     opts.separator '                    [--list-parse-options] [--parse-option=OPTION]'
     opts.separator '                    [--list-render-options] [--render-option=OPTION]'
     opts.separator '                    [FILE..]'
@@ -30,11 +30,13 @@ def parse_options
     opts.separator 'If no FILE argument is provided, text will be read from STDIN.'
     opts.separator ''
 
-    opts.on('--extension=EXTENSION', 'Use EXTENSION for parsing and HTML output unless --html-renderer is specified') do |value|
-      if extensions.include?(value)
-        options.active_extensions << value.to_sym
-      else
-        abort("extension '#{value}' not found")
+    opts.on('--extension=EXTENSION', Array, 'Use EXTENSION for parsing and HTML output unless --html-renderer is specified') do |values|
+      values.each do |value|
+        if extensions.include?(value)
+          options.active_extensions << value.to_sym
+        else
+          abort("extension '#{value}' not found")
+        end
       end
     end
 
@@ -62,23 +64,27 @@ def parse_options
       exit
     end
 
-    opts.on('--parse-option=OPTION', 'OPTION will be passed during parsing') do |value|
-      if parse_options.key?(value.to_sym)
-        options.active_parse_options << value.to_sym
-      else
-        abort("parse-option '#{value}' not found")
+    opts.on('--parse-option=OPTION', Array, 'OPTION will be passed during parsing') do |values|
+      values.each do |value|
+        if parse_options.key?(value.to_sym)
+          options.active_parse_options << value.to_sym
+        else
+          abort("parse-option '#{value}' not found")
+        end
       end
     end
 
-    opts.on('--render-option=OPTION', 'OPTION will be passed during rendering') do |value|
-      if render_options.key?(value.to_sym)
-        options.active_render_options << value.to_sym
-      else
-        abort("render-option '#{value}' not found")
+    opts.on('--render-option=OPTION', Array, 'OPTION will be passed during rendering') do |values|
+      values.each do |value|
+        if render_options.key?(value.to_sym)
+          options.active_render_options << value.to_sym
+        else
+          abort("render-option '#{value}' not found")
+        end
       end
     end
 
-    opts.on("-v", "--version", 'Version information') do
+    opts.on('-v', '--version', 'Version information') do
       puts "commonmarker #{CommonMarker::VERSION}"
       exit
     end
@@ -86,7 +92,7 @@ def parse_options
 
   option_parser.parse!
 
-  return options
+  options
 end
 
 options = parse_options

--- a/test/fixtures/strong.md
+++ b/test/fixtures/strong.md
@@ -1,0 +1,1 @@
+I am **strong**

--- a/test/fixtures/table.md
+++ b/test/fixtures/table.md
@@ -1,0 +1,10 @@
+One extension:
+
+| a   | b   |
+| --- | --- |
+| c   | d   |
+| **x** | |
+
+Another extension:
+
+~~hi~~

--- a/test/test_attributes.rb
+++ b/test/test_attributes.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class TestAttributes < Minitest::Test
   def setup
-    contents = File.read(File.join(FIXTURES_DIR, 'dingus.md'))
+    contents = fixtures_file('dingus.md')
     @doc = CommonMarker.render_doc(contents.strip)
   end
 

--- a/test/test_commands.rb
+++ b/test/test_commands.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestCommands < Minitest::Test
+  def test_basic
+    out = make_bin('strong.md')
+    assert_equal out, '<p>I am <strong>strong</strong></p>'
+  end
+
+  def test_does_not_have_extensions
+    out = make_bin('table.md')
+    assert out.include?('| a')
+    refute out.include?('<p><del>hi</del>')
+    refute out.include?('<table> <tr> <th> a </th> <td> c </td>')
+  end
+
+  def test_understands_extensions
+    out = make_bin('table.md', '--extension=table')
+    refute out.include?('| a')
+    refute out.include?('<p><del>hi</del>')
+    %w[<table> <tr> <th> a </th> <td> c </td>].each { |html| assert out.include?(html) }
+  end
+
+  def test_understands_multiple_extensions
+    out = make_bin('table.md', '--extension=table,strikethrough')
+    refute out.include?('| a')
+    assert out.include?('<p><del>hi</del>')
+    %w[<table> <tr> <th> a </th> <td> c </td>].each { |html| assert out.include?(html) }
+  end
+end

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -6,7 +6,7 @@ require 'test_helper'
 class TestEncoding < Minitest::Test
   # see http://git.io/vq4FR
   def test_encoding
-    contents = File.read(File.join(FIXTURES_DIR, 'curly.md'), encoding: 'utf-8')
+    contents = fixtures_file('curly.md')
     doc = CommonMarker.render_doc(contents, :SMART)
     render = doc.to_html
     assert_equal render.rstrip, '<p>This curly quote “makes commonmarker throw an exception”.</p>'

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -4,18 +4,7 @@ require 'test_helper'
 
 class TestExtensions < Minitest::Test
   def setup
-    @markdown = <<-MD
-One extension:
-
-| a   | b   |
-| --- | --- |
-| c   | d   |
-| **x** | |
-
-Another extension:
-
-~~hi~~
-    MD
+    @markdown = fixtures_file('table.md')
   end
 
   def test_uses_specified_extensions

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,7 @@ def fixtures_file(file)
 end
 
 def make_bin(file, args = '')
-  `bin/commonmarker '#{File.join(FIXTURES_DIR, file)}' #{args}`.chomp
+  `ruby bin/commonmarker #{File.join(FIXTURES_DIR, file)} #{args}`.chomp
 end
 
 def open_spec_file(filename)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,7 @@ def fixtures_file(file)
 end
 
 def make_bin(file, args = '')
-  system("bin/commonmarker #{File.join(FIXTURES_DIR, file)} #{args}").chomp
+  `bin/commonmarker '#{File.join(FIXTURES_DIR, file)}' #{args}`.chomp
 end
 
 def open_spec_file(filename)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,14 @@ include CommonMarker
 
 FIXTURES_DIR = File.join(File.dirname(__FILE__), 'fixtures')
 
+def fixtures_file(file)
+  File.read(File.join(FIXTURES_DIR, file), encoding: 'utf-8')
+end
+
+def make_bin(file, args = '')
+  `bin/commonmarker #{File.join(FIXTURES_DIR, file)} #{args}`.chomp
+end
+
 def open_spec_file(filename)
   line_number = 0
   start_line = 0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,7 @@ def fixtures_file(file)
 end
 
 def make_bin(file, args = '')
-  `bin/commonmarker #{File.join(FIXTURES_DIR, file)} #{args}`.chomp
+  system("bin/commonmarker #{File.join(FIXTURES_DIR, file)} #{args}").chomp
 end
 
 def open_spec_file(filename)


### PR DESCRIPTION
Added support for `--list-parse-options`, `--parse-option=OPTION`, `--list-render-options`, and `--render-option=OPTION` on the command line.

I always find I want to pass in `SOURCEPOS` and other options 😄 