### PR TITLE
Call out to C when available for custom rendering

### DIFF
--- a/test/test_renderer.rb
+++ b/test/test_renderer.rb
@@ -3,6 +3,19 @@
 require 'test_helper'
 
 class TestRenderer < Minitest::Test
+  class CustomCommonMarker < CommonMarker::HtmlRenderer
+    attr_accessor :link_attributes
+
+    def link(node)
+      # Based on https://github.com/gjtorikian/commonmarker/blob/1fe234820a77cb3f2b26b47971d229d0da92d652/lib/commonmarker/renderer/html_renderer.rb#L130-L136
+      attributes = { href: node.url.nil? ? '' : escape_href(node.url) }
+      attributes[:title] = escape_html(node.title) if node.title
+      attributes.merge!(link_attributes || {})
+      formatted_attrs = attributes.map { |k, v| "#{k}=\"#{v}\"" }.join(' ')
+      out("<a #{formatted_attrs}>", :children, '</a>')
+    end
+  end
+
   def setup
     @doc = CommonMarker.render_doc('Hi *there*')
   end
@@ -26,5 +39,19 @@ class TestRenderer < Minitest::Test
     doc = CommonMarker.render_doc(content, :DEFAULT, %i[autolink table tagfilter])
     results = CommonMarker::HtmlRenderer.new.render(doc)
     assert_equal 2, results.scan(/<tbody>/).size
+  end
+
+  def test_custom_render_speed
+    content = <<~DOC
+      **wow**
+
+      [foo]: /url "title"
+
+      [foo]
+    DOC
+    doc = CommonMarker.render_doc(content, :DEFAULT, %i[autolink table tagfilter])
+    results = CustomCommonMarker.new.render(doc)
+    output = "<p><strong>wow</strong></p>\n<p><a href=\"/url\" title=\"title\">foo</a></p>\n"
+    assert_equal output, results
   end
 end


### PR DESCRIPTION
Attempt to close https://github.com/gjtorikian/commonmarker/issues/112.

The goal of this PR is to have a custom renderer call into the C rendering code with possible, rather than constructing the strings in Ruby. This could be particularly useful if you only have one overridden method (`link`) and want the default C rendering when possible.

The way the custom renderer works is by stepping through each type:

https://github.com/gjtorikian/commonmarker/blob/33a9e200d0d36fd6c837295e3b5143249a16e406/lib/commonmarker/renderer.rb#L42

But if a subclass defines a method a problem occurs if the node.type is a block element, like a paragraph. Right now, it goes into the Ruby code, opens some `<p` tag, then steps through all the elements of the paragraph and renders them one by one. But, if we changed this to say, "always go to the C code," the C code slurps up all the nodes found within that paragraph. In other words it doesn't jump back into Ruby to render an inline item. This makes the custom renderer somewhat useless.

To get around this, we should only jump into C for inline types, not block types. If an inline type is not being overwritten in a custom renderer, we'll fall back to the default C renderer.

@movermeyer I'd be curious if you could run that benchmark again on this branch and report back if it improves things. It might not, because now we're jumping back and forth between C and Ruby. But who knows, there might be a slight performance gain that makes it worthwhile to merge.