### PR TITLE
Avoid a YARD annotation warning

### DIFF
--- a/lib/commonmarker/node/inspect.rb
+++ b/lib/commonmarker/node/inspect.rb
@@ -11,7 +11,7 @@ module CommonMarker
         PP.pp(self, +'', Float::INFINITY)
       end
 
-      # @param [PrettyPrint] pp
+      # @param printer [PrettyPrint] pp
       def pretty_print(printer)
         printer.group(PP_INDENT_SIZE, "#<#{self.class}(#{type}):", '>') do
           printer.breakable


### PR DESCRIPTION
This PR fixes a warning like:

> Building YARD (yri) index for commonmarker-0.21.0...
> lib/commonmarker/node/inspect.rb:14: [UnknownParam] @param tag has unknown parameter name: pp