### PR TITLE
Fix mismatched indentation

### DIFF
--- a/lib/commonmarker/renderer/html_renderer.rb
+++ b/lib/commonmarker/renderer/html_renderer.rb
@@ -70,7 +70,7 @@ module CommonMarker
                 'checked="" disabled=""'
               else
                 'disabled=""'
-      end
+              end
       "><input type=\"checkbox\" #{state} /"
     end
 


### PR DESCRIPTION
This mismatched indentation causes following warning message when running codes with `-w` flag.

```
/Users/naoty/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/commonmarker-0.21.0/lib/commonmarker/renderer/html_renderer.rb:73: warning: mismatched indentations at 'end' with 'else' at 71
```