### PR TITLE
Copy encoding when escaping hrefs/HTML

### DIFF
--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -45,6 +45,13 @@ static VALUE encode_utf8_string(const char *c_string) {
   return string;
 }
 
+/* Encode a C string using the encoding from Ruby string +source+. */
+static VALUE encode_source_string(const char *c_string, VALUE source) {
+  VALUE string = rb_str_new2(c_string);
+  rb_enc_copy(string, source);
+  return string;
+}
+
 static void rb_mark_c_struct(void *data) {
   cmark_node *node = data;
   cmark_node *child;
@@ -1120,7 +1127,6 @@ static VALUE rb_node_get_table_alignments(VALUE self) {
 static VALUE rb_html_escape_href(VALUE self, VALUE rb_text) {
   char *result;
   cmark_node *node;
-  VALUE escaped;
   Check_Type(rb_text, T_STRING);
 
   Data_Get_Struct(self, cmark_node, node);
@@ -1131,9 +1137,7 @@ static VALUE rb_html_escape_href(VALUE self, VALUE rb_text) {
   if (houdini_escape_href(&buf, (const uint8_t *)RSTRING_PTR(rb_text),
                           RSTRING_LEN(rb_text))) {
     result = (char *)cmark_strbuf_detach(&buf);
-    escaped = rb_str_new2(result);
-    rb_enc_copy(escaped, rb_text);
-    return escaped;
+    return encode_source_string(result, rb_text);
 
   }
 
@@ -1144,7 +1148,6 @@ static VALUE rb_html_escape_href(VALUE self, VALUE rb_text) {
 static VALUE rb_html_escape_html(VALUE self, VALUE rb_text) {
   char *result;
   cmark_node *node;
-  VALUE escaped;
   Check_Type(rb_text, T_STRING);
 
   Data_Get_Struct(self, cmark_node, node);
@@ -1155,9 +1158,7 @@ static VALUE rb_html_escape_html(VALUE self, VALUE rb_text) {
   if (houdini_escape_html0(&buf, (const uint8_t *)RSTRING_PTR(rb_text),
                            RSTRING_LEN(rb_text), 0)) {
     result = (char *)cmark_strbuf_detach(&buf);
-    escaped = rb_str_new2(result);
-    rb_enc_copy(escaped, rb_text);
-    return escaped;
+    return encode_source_string(result, rb_text);
   }
 
   return rb_text;

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -1120,6 +1120,7 @@ static VALUE rb_node_get_table_alignments(VALUE self) {
 static VALUE rb_html_escape_href(VALUE self, VALUE rb_text) {
   char *result;
   cmark_node *node;
+  VALUE escaped;
   Check_Type(rb_text, T_STRING);
 
   Data_Get_Struct(self, cmark_node, node);
@@ -1130,7 +1131,10 @@ static VALUE rb_html_escape_href(VALUE self, VALUE rb_text) {
   if (houdini_escape_href(&buf, (const uint8_t *)RSTRING_PTR(rb_text),
                           RSTRING_LEN(rb_text))) {
     result = (char *)cmark_strbuf_detach(&buf);
-    return rb_str_new2(result);
+    escaped = rb_str_new2(result);
+    rb_enc_copy(escaped, rb_text);
+    return escaped;
+
   }
 
   return rb_text;
@@ -1140,6 +1144,7 @@ static VALUE rb_html_escape_href(VALUE self, VALUE rb_text) {
 static VALUE rb_html_escape_html(VALUE self, VALUE rb_text) {
   char *result;
   cmark_node *node;
+  VALUE escaped;
   Check_Type(rb_text, T_STRING);
 
   Data_Get_Struct(self, cmark_node, node);
@@ -1150,7 +1155,9 @@ static VALUE rb_html_escape_html(VALUE self, VALUE rb_text) {
   if (houdini_escape_html0(&buf, (const uint8_t *)RSTRING_PTR(rb_text),
                            RSTRING_LEN(rb_text), 0)) {
     result = (char *)cmark_strbuf_detach(&buf);
-    return rb_str_new2(result);
+    escaped = rb_str_new2(result);
+    rb_enc_copy(escaped, rb_text);
+    return escaped;
   }
 
   return rb_text;

--- a/test/test_renderer.rb
+++ b/test/test_renderer.rb
@@ -27,4 +27,21 @@ class TestRenderer < Minitest::Test
     results = CommonMarker::HtmlRenderer.new.render(doc)
     assert_equal 2, results.scan(/<tbody>/).size
   end
+
+  def test_escape_html_encoding
+    my_renderer = Class.new(HtmlRenderer) do
+      attr_reader :input_encoding, :output_encoding
+
+      def text(node)
+        @input_encoding = node.string_content.encoding
+        escape_html(node.string_content).tap do |escaped|
+          @output_encoding = escaped.encoding
+        end
+      end
+    end
+
+    renderer = my_renderer.new
+    assert_equal Encoding::UTF_8, renderer.render(@doc).encoding
+    assert_equal renderer.input_encoding, renderer.output_encoding
+  end
 end


### PR DESCRIPTION
Fixes #130.

Looking at this code makes me feel weird. I guess we kind of leak `result` in these methods. They're allocated from the arena the node belongs to, so they get reset whenever `rb_markdown_to_html` is called, which should be often enough, but if people don't use that method, these might be leaky.