### PR TITLE
HtmlRenderer - open links in new tab

### DIFF
--- a/lib/commonmarker/renderer/html_renderer.rb
+++ b/lib/commonmarker/renderer/html_renderer.rb
@@ -134,7 +134,7 @@ module CommonMarker
     end
 
     def link(node)
-      out('<a href="', node.url.nil? ? '' : escape_href(node.url), '"')
+      out('<a href="', node.url.nil? ? '' : escape_href(node.url), '" target="_blank" rel="noopener"')
       out(' title="', escape_html(node.title), '"') if node.title && !node.title.empty?
       out('>', :children, '</a>')
     end


### PR DESCRIPTION
PR makes `HtmlRenderer` links open in new tab 

Note that `noopener` is [now implicit](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target) on most recent browser versions, but added for ensuring behaviour in older browser versions.

Regards,
