### PR TITLE
Add support for rendering XML from cmark-gfm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.bundle
 /.config
 /coverage/
+/.idea
 /InstalledFiles
 /pkg/
 /spec/reports/

--- a/README.md
+++ b/README.md
@@ -180,6 +180,76 @@ The available extensions are:
 * `:autolink` - This provides support for automatically converting URLs to anchor tags.
 * `:tagfilter` - This escapes [several "unsafe" HTML tags](https://github.github.com/gfm/#disallowed-raw-html-extension-), causing them to not have any effect.
 
+## Output formats
+
+Like CMark, CommonMarker can generate output in several formats: HTML, XML, plaintext, and commonmark are currently supported.
+
+### HTML
+
+The default output format, HTML, will be generated when calling `to_html` or using `--to=html` on the command line.
+
+```ruby
+doc = CommonMarker.render_doc('*Hello* world!', :DEFAULT)
+puts(doc.to_html)
+
+<p><em>Hello</em> world!</p>
+```
+
+### XML
+
+XML will be generated when calling `to_xml` or using `--to=xml` on the command line.
+
+```ruby
+doc = CommonMarker.render_doc('*Hello* world!', :DEFAULT)
+puts(doc.to_xml)
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE document SYSTEM "CommonMark.dtd">
+<document xmlns="http://commonmark.org/xml/1.0">
+  <paragraph>
+    <emph>
+      <text xml:space="preserve">Hello</text>
+    </emph>
+    <text xml:space="preserve"> world!</text>
+  </paragraph>
+</document>
+```
+
+### Plaintext
+
+Plaintext will be generated when calling `to_plaintext` or using `--to=plaintext` on the command line.
+
+```ruby
+doc = CommonMarker.render_doc('*Hello* world!', :DEFAULT)
+puts(doc.to_plaintext)
+
+Hello world!
+```
+
+### Commonmark
+
+Commonmark will be generated when calling `to_commonmark` or using `--to=commonmark` on the command line.
+
+``` ruby
+text = <<-TEXT
+1. I am a numeric list.
+2. I continue the list.
+* Suddenly, an unordered list!
+* What fun!
+TEXT
+
+doc = CommonMarker.render_doc(text, :DEFAULT)
+puts(doc.to_commonmark)
+
+1.  I am a numeric list.
+2.  I continue the list.
+
+<!-- end list -->
+
+  - Suddenly, an unordered list\!
+  - What fun\!
+```
+
 ## Developing locally
 
 After cloning the repo:

--- a/bin/commonmarker
+++ b/bin/commonmarker
@@ -57,7 +57,11 @@ def parse_options
 
     opts.on('-tFORMAT', '--to=FORMAT', String, 'Specify output FORMAT') do |value|
       value = value.to_sym
-      options.output_format = value if format_options.include?(value)
+      if format_options.include?(value)
+        options.output_format = value
+      else
+        abort("format '#{value}' not found")
+      end
     end
 
     opts.on('--html-renderer', 'Use the HtmlRenderer renderer rather than the native C renderer (only valid when format is html)') do
@@ -96,6 +100,10 @@ def parse_options
 end
 
 options = parse_options
+
+abort("format '#{options.output_format}' does not support using the HtmlRenderer renderer") if
+  options.renderer && options.output_format != :html
+
 doc = CommonMarker.render_doc(ARGF.read, options.active_parse_options, options.active_extensions)
 
 case options.output_format

--- a/bin/commonmarker
+++ b/bin/commonmarker
@@ -15,13 +15,16 @@ def parse_options
   extensions = CommonMarker.extensions
   parse_options = CommonMarker::Config::OPTS.fetch(:parse)
   render_options = CommonMarker::Config::OPTS.fetch(:render)
+  format_options = CommonMarker::Config::OPTS.fetch(:format)
 
   options.active_extensions = []
   options.active_parse_options = [:DEFAULT]
   options.active_render_options = [:DEFAULT]
+  options.output_format = :html
 
   option_parser = OptionParser.new do |opts|
     opts.banner = 'Usage: commonmarker [--html-renderer] [--extension=EXTENSION]'
+    opts.separator '                    [--to=FORMAT]'
     opts.separator '                    [--parse-option=OPTION]'
     opts.separator '                    [--render-option=OPTION]'
     opts.separator '                    [FILE..]'
@@ -43,6 +46,7 @@ def parse_options
     opts.on('-h', '--help', 'Prints this help') do
       puts opts
       puts
+      puts "Available formats: #{format_options.join(', ')}"
       puts "Available extentions: #{extensions.join(', ')}"
       puts "Available parse options: #{parse_options.keys.join(', ')}"
       puts "Available render options: #{render_options.keys.join(', ')}"
@@ -51,7 +55,12 @@ def parse_options
       exit
     end
 
-    opts.on('--html-renderer', 'Use the HtmlRenderer renderer rather than the native C renderer') do
+    opts.on('-tFORMAT', '--to=FORMAT', String, 'Specify output format (html, xml)') do |value|
+      value = value.to_sym
+      options.output_format = value if format_options.include?(value)
+    end
+
+    opts.on('--html-renderer', 'Use the HtmlRenderer renderer rather than the native C renderer (only valid when format is html)') do
       options.renderer = true
     end
 
@@ -87,12 +96,16 @@ def parse_options
 end
 
 options = parse_options
-
 doc = CommonMarker.render_doc(ARGF.read, options.active_parse_options, options.active_extensions)
 
-if options.renderer
-  renderer = CommonMarker::HtmlRenderer.new(extensions: options.active_extensions)
-  $stdout.write(renderer.render(doc))
-else
-  $stdout.write(doc.to_html(options.active_render_options, options.active_extensions))
+case options.output_format
+when :html
+  if options.renderer
+    renderer = CommonMarker::HtmlRenderer.new(options: options.active_render_options, extensions: options.active_extensions)
+    $stdout.write(renderer.render(doc))
+  else
+    $stdout.write(doc.to_html(options.active_render_options, options.active_extensions))
+  end
+when :xml
+  $stdout.write(doc.to_xml(options.active_render_options))
 end

--- a/bin/commonmarker
+++ b/bin/commonmarker
@@ -55,7 +55,7 @@ def parse_options
       exit
     end
 
-    opts.on('-tFORMAT', '--to=FORMAT', String, 'Specify output format (html, xml)') do |value|
+    opts.on('-tFORMAT', '--to=FORMAT', String, 'Specify output FORMAT') do |value|
       value = value.to_sym
       options.output_format = value if format_options.include?(value)
     end
@@ -108,4 +108,8 @@ when :html
   end
 when :xml
   $stdout.write(doc.to_xml(options.active_render_options))
+when :commonmark
+  $stdout.write(doc.to_commonmark(options.active_render_options))
+when :plaintext
+  $stdout.write(doc.to_plaintext(options.active_render_options))
 end

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -24,7 +24,8 @@ module CommonMarker
         FULL_INFO_STRING: (1 << 16),
         UNSAFE: (1 << 17),
         FOOTNOTES: (1 << 13)
-      }.freeze
+      }.freeze,
+      format: %i[html xml].freeze
     }.freeze
 
     def self.process_options(option, type)

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -25,7 +25,7 @@ module CommonMarker
         UNSAFE: (1 << 17),
         FOOTNOTES: (1 << 13)
       }.freeze,
-      format: %i[html xml].freeze
+      format: %i[html xml commonmark plaintext].freeze
     }.freeze
 
     def self.process_options(option, type)

--- a/lib/commonmarker/node.rb
+++ b/lib/commonmarker/node.rb
@@ -30,6 +30,16 @@ module CommonMarker
       _render_html(opts, extensions).force_encoding('utf-8')
     end
 
+    # Public: Convert the node to an XML string.
+    #
+    # options - A {Symbol} or {Array of Symbol}s indicating the render options
+    #
+    # Returns a {String}.
+    def to_xml(options = :DEFAULT)
+      opts = Config.process_options(options, :render)
+      _render_xml(opts).force_encoding('utf-8')
+    end
+
     # Public: Convert the node to a CommonMark string.
     #
     # options - A {Symbol} or {Array of Symbol}s indicating the render options

--- a/test/test_commands.rb
+++ b/test/test_commands.rb
@@ -28,4 +28,10 @@ class TestCommands < Minitest::Test
     assert_includes out, '<p><del>hi</del>'
     %w[<table> <tr> <th> a </th> <td> c </td>].each { |html| assert_includes out, html }
   end
+
+  def test_understands_format
+    out = make_bin('strong.md', '--to=xml')
+    assert_includes out, '<?xml version="1.0" encoding="UTF-8"?>'
+    assert_includes out, '<text xml:space="preserve">strong</text>'
+  end
 end

--- a/test/test_commands.rb
+++ b/test/test_commands.rb
@@ -29,9 +29,19 @@ class TestCommands < Minitest::Test
     %w[<table> <tr> <th> a </th> <td> c </td>].each { |html| assert_includes out, html }
   end
 
-  def test_understands_format
+  def test_understands_xml_format
     out = make_bin('strong.md', '--to=xml')
     assert_includes out, '<?xml version="1.0" encoding="UTF-8"?>'
     assert_includes out, '<text xml:space="preserve">strong</text>'
+  end
+
+  def test_understands_commonmark_format
+    out = make_bin('strong.md', '--to=commonmark')
+    assert_equal('I am **strong**', out)
+  end
+
+  def test_understands_plaintext_format
+    out = make_bin('strong.md', '--to=plaintext')
+    assert_equal('I am strong', out)
   end
 end

--- a/test/test_commands.rb
+++ b/test/test_commands.rb
@@ -29,6 +29,13 @@ class TestCommands < Minitest::Test
     %w[<table> <tr> <th> a </th> <td> c </td>].each { |html| assert_includes out, html }
   end
 
+  def test_understands_html_format_with_renderer_and_extensions
+    out = make_bin('table.md', '--to=html --extension=table,strikethrough --html-renderer')
+    refute_includes out, '| a'
+    assert_includes out, '<p><del>hi</del>'
+    %w[<table> <tr> <th> a </th> <td> c </td>].each { |html| assert_includes out, html }
+  end
+
   def test_understands_xml_format
     out = make_bin('strong.md', '--to=xml')
     assert_includes out, '<?xml version="1.0" encoding="UTF-8"?>'
@@ -43,5 +50,23 @@ class TestCommands < Minitest::Test
   def test_understands_plaintext_format
     out = make_bin('strong.md', '--to=plaintext')
     assert_equal('I am strong', out)
+  end
+
+  def test_aborts_invalid_format
+    _out, err = capture_subprocess_io do
+      make_bin('strong.md', '--to=unknown')
+    end
+
+    assert_match "format 'unknown' not found", err
+  end
+
+  def test_aborts_format_and_html_renderer_combinations
+    (CommonMarker::Config::OPTS[:format] - [:html]).each do |format|
+      _out, err = capture_subprocess_io do
+        make_bin('strong.md', "--to=#{format} --html-renderer")
+      end
+
+      assert_match "format '#{format}' does not support using the HtmlRenderer renderer", err
+    end
   end
 end

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -9,6 +9,9 @@ class TestEncoding < Minitest::Test
     doc = CommonMarker.render_doc(contents, :SMART)
     render = doc.to_html
     assert_equal('<p>This curly quote “makes commonmarker throw an exception”.</p>', render.rstrip)
+
+    render = doc.to_xml
+    assert_includes(render, '<text xml:space="preserve">This curly quote “makes commonmarker throw an exception”.</text>')
   end
 
   def test_string_content_is_utf8

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestXml < Minitest::Test
+  def setup
+    @markdown = <<~MD
+      Hi *there*!
+
+      1. I am a numeric list.
+      2. I continue the list.
+      * Suddenly, an unordered list!
+      * What fun!
+
+      Okay, _enough_.
+
+      | a   | b   |
+      | --- | --- |
+      | c   | d   |
+    MD
+  end
+
+  def render_doc(doc)
+    CommonMarker.render_doc(doc, :DEFAULT, [:table])
+  end
+
+  def test_to_commonmark
+    compare = render_doc(@markdown).to_xml(:SOURCEPOS)
+
+    assert_equal <<~XML, compare
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE document SYSTEM "CommonMark.dtd">
+      <document sourcepos="1:1-12:13" xmlns="http://commonmark.org/xml/1.0">
+        <paragraph sourcepos="1:1-1:11">
+          <text sourcepos="1:1-1:3" xml:space="preserve">Hi </text>
+          <emph sourcepos="1:4-1:10">
+            <text sourcepos="1:5-1:9" xml:space="preserve">there</text>
+          </emph>
+          <text sourcepos="1:11-1:11" xml:space="preserve">!</text>
+        </paragraph>
+        <list sourcepos="3:1-4:23" type="ordered" start="1" delim="period" tight="true">
+          <item sourcepos="3:1-3:23">
+            <paragraph sourcepos="3:4-3:23">
+              <text sourcepos="3:4-3:23" xml:space="preserve">I am a numeric list.</text>
+            </paragraph>
+          </item>
+          <item sourcepos="4:1-4:23">
+            <paragraph sourcepos="4:4-4:23">
+              <text sourcepos="4:4-4:23" xml:space="preserve">I continue the list.</text>
+            </paragraph>
+          </item>
+        </list>
+        <list sourcepos="5:1-7:0" type="bullet" tight="true">
+          <item sourcepos="5:1-5:30">
+            <paragraph sourcepos="5:3-5:30">
+              <text sourcepos="5:3-5:30" xml:space="preserve">Suddenly, an unordered list!</text>
+            </paragraph>
+          </item>
+          <item sourcepos="6:1-7:0">
+            <paragraph sourcepos="6:3-6:11">
+              <text sourcepos="6:3-6:11" xml:space="preserve">What fun!</text>
+            </paragraph>
+          </item>
+        </list>
+        <paragraph sourcepos="8:1-8:15">
+          <text sourcepos="8:1-8:6" xml:space="preserve">Okay, </text>
+          <emph sourcepos="8:7-8:14">
+            <text sourcepos="8:8-8:13" xml:space="preserve">enough</text>
+          </emph>
+          <text sourcepos="8:15-8:15" xml:space="preserve">.</text>
+        </paragraph>
+        <table sourcepos="10:1-12:13">
+          <table_header sourcepos="10:1-10:13">
+            <table_cell sourcepos="10:2-10:6">
+              <text sourcepos="10:3-10:3" xml:space="preserve">a</text>
+            </table_cell>
+            <table_cell sourcepos="10:8-10:12">
+              <text sourcepos="10:9-10:9" xml:space="preserve">b</text>
+            </table_cell>
+          </table_header>
+          <table_row sourcepos="12:1-12:13">
+            <table_cell sourcepos="12:2-12:6">
+              <text sourcepos="12:3-12:3" xml:space="preserve">c</text>
+            </table_cell>
+            <table_cell sourcepos="12:8-12:12">
+              <text sourcepos="12:9-12:9" xml:space="preserve">d</text>
+            </table_cell>
+          </table_row>
+        </table>
+      </document>
+    XML
+  end
+end

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -24,7 +24,7 @@ class TestXml < Minitest::Test
     CommonMarker.render_doc(doc, :DEFAULT, [:table])
   end
 
-  def test_to_commonmark
+  def test_to_xml
     compare = render_doc(@markdown).to_xml(:SOURCEPOS)
 
     assert_equal <<~XML, compare
@@ -87,6 +87,20 @@ class TestXml < Minitest::Test
             </table_cell>
           </table_row>
         </table>
+      </document>
+    XML
+  end
+
+  def test_to_xml_with_quotes
+    compare = render_doc('"quotes" should be escaped').to_xml(:DEFAULT)
+
+    assert_equal <<~XML, compare
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE document SYSTEM "CommonMark.dtd">
+      <document xmlns="http://commonmark.org/xml/1.0">
+        <paragraph>
+          <text xml:space="preserve">&quot;quotes&quot; should be escaped</text>
+        </paragraph>
       </document>
     XML
   end


### PR DESCRIPTION
`cmark-gfm` supports rending to the XML format and exports the correct functions.  So I've added support to the `Node` class so you can now do `doc.to_xml`.

Also added support for a new command line option, `—to=FORMAT` (which mirrors the option in `cmark-gfm`) that allows you to specify the output format.  Since `to_plaintext` and `to_commonmark` were already supported internally, possible output formats is `html`, `xml`, `plaintext`, and `CommonMark`. For example `commonmarker --to=xml`

Currently `man` and `latex` are not supported output formats.
