### PR TITLE
Normalize parse and render options

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,26 +130,31 @@ CommonMarker accepts the same options that CMark does, as symbols. Note that the
 | Name                          | Description
 | ----------------------------- | -----------
 | `:DEFAULT`                    | The default parsing system.
+| `:SOURCEPOS`                  | Include source position in nodes
 | `:UNSAFE`                     | Allow raw/custom HTML and unsafe links.
-| `:FOOTNOTES`                  | Parse footnotes.
-| `:LIBERAL_HTML_TAG`           | Support liberal parsing of inline HTML tags.
-| `:SMART`                      | Use smart punctuation (curly quotes, etc.).
-| `:STRIKETHROUGH_DOUBLE_TILDE` | Parse strikethroughs by double tildes (compatibility with [redcarpet](https://github.com/vmg/redcarpet))
 | `:VALIDATE_UTF8`              | Replace illegal sequences with the replacement character `U+FFFD`.
+| `:SMART`                      | Use smart punctuation (curly quotes, etc.).
+| `:LIBERAL_HTML_TAG`           | Support liberal parsing of inline HTML tags.
+| `:FOOTNOTES`                  | Parse footnotes.
+| `:STRIKETHROUGH_DOUBLE_TILDE` | Parse strikethroughs by double tildes (compatibility with [redcarpet](https://github.com/vmg/redcarpet))
 
 ### Render options
 
 | Name                             | Description                                                     |
 | ------------------               | -----------                                                     |
 | `:DEFAULT`                       | The default rendering system.                                   |
-| `:UNSAFE`                        | Allow raw/custom HTML and unsafe links.                         |
-| `:GITHUB_PRE_LANG`               | Use GitHub-style `<pre lang>` for fenced code blocks.           |
-| `:HARDBREAKS`                    | Treat `\n` as hardbreaks (by adding `<br/>`).                   |
-| `:NOBREAKS`                      | Translate `\n` in the source to a single whitespace.            |
 | `:SOURCEPOS`                     | Include source position in rendered HTML.                       |
+| `:HARDBREAKS`                    | Treat `\n` as hardbreaks (by adding `<br/>`).                   |
+| `:UNSAFE`                        | Allow raw/custom HTML and unsafe links.                         |
+| `:NOBREAKS`                      | Translate `\n` in the source to a single whitespace.            |
+| `:VALIDATE_UTF8`                 | Replace illegal sequences with the replacement character `U+FFFD`. |
+| `:SMART`                         | Use smart punctuation (curly quotes, etc.).                     |
+| `:GITHUB_PRE_LANG`               | Use GitHub-style `<pre lang>` for fenced code blocks.           |
+| `:LIBERAL_HTML_TAG`              | Support liberal parsing of inline HTML tags.                    |
+| `:FOOTNOTES`                     | Render footnotes.                                               |
+| `:STRIKETHROUGH_DOUBLE_TILDE`    | Parse strikethroughs by double tildes (compatibility with [redcarpet](https://github.com/vmg/redcarpet)) |
 | `:TABLE_PREFER_STYLE_ATTRIBUTES` | Use `style` insted of `align` for table cells.                  |
 | `:FULL_INFO_STRING`              | Include full info strings of code blocks in separate attribute. |
-| `:FOOTNOTES`                     | Render footnotes.                                               |
 
 ### Passing options
 

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -8,7 +8,7 @@ module CommonMarker
       parse: {
         DEFAULT: 0,
         SOURCEPOS: (1 << 1),
-        UNSAFE: (1 << 17)
+        UNSAFE: (1 << 17),
         VALIDATE_UTF8: (1 << 9),
         SMART: (1 << 10),
         LIBERAL_HTML_TAG: (1 << 12),
@@ -25,7 +25,7 @@ module CommonMarker
         SMART: (1 << 10),
         GITHUB_PRE_LANG: (1 << 11),
         LIBERAL_HTML_TAG: (1 << 12),
-        FOOTNOTES: (1 << 13)
+        FOOTNOTES: (1 << 13),
         STRIKETHROUGH_DOUBLE_TILDE: (1 << 14),
         TABLE_PREFER_STYLE_ATTRIBUTES: (1 << 15),
         FULL_INFO_STRING: (1 << 16),

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -7,23 +7,28 @@ module CommonMarker
     OPTS = {
       parse: {
         DEFAULT: 0,
+        SOURCEPOS: (1 << 1),
+        UNSAFE: (1 << 17)
         VALIDATE_UTF8: (1 << 9),
         SMART: (1 << 10),
         LIBERAL_HTML_TAG: (1 << 12),
         FOOTNOTES: (1 << 13),
         STRIKETHROUGH_DOUBLE_TILDE: (1 << 14),
-        UNSAFE: (1 << 17)
       }.freeze,
       render: {
         DEFAULT: 0,
         SOURCEPOS: (1 << 1),
         HARDBREAKS: (1 << 2),
+        UNSAFE: (1 << 17),
         NOBREAKS: (1 << 4),
+        VALIDATE_UTF8: (1 << 9),
+        SMART: (1 << 10),
         GITHUB_PRE_LANG: (1 << 11),
+        LIBERAL_HTML_TAG: (1 << 12),
+        FOOTNOTES: (1 << 13)
+        STRIKETHROUGH_DOUBLE_TILDE: (1 << 14),
         TABLE_PREFER_STYLE_ATTRIBUTES: (1 << 15),
         FULL_INFO_STRING: (1 << 16),
-        UNSAFE: (1 << 17),
-        FOOTNOTES: (1 << 13)
       }.freeze
     }.freeze
 

--- a/test/test_basics.rb
+++ b/test/test_basics.rb
@@ -15,4 +15,21 @@ class TestBasics < Minitest::Test
     html = CommonMarker.render_html('Hi *there*')
     assert_equal "<p>Hi <em>there</em></p>\n", html
   end
+
+  # basic test that just checks if every option is accepted & no errors are thrown
+  def test_accept_every_option
+    text = "Hello **world** -- how are _you_ today? I'm ~~fine~~, ~yourself~?"
+    parse_opt = [:SOURCEPOS, :UNSAFE, :VALIDATE_UTF8, :SMART, :LIBERAL_HTML_TAG, :FOOTNOTES, :STRIKETHROUGH_DOUBLE_TILDE]
+    render_opt = parse_opt + [:HARDBREAKS, :NOBREAKS, :GITHUB_PRE_LANG, :TABLE_PREFER_STYLE_ATTRIBUTES, :FULL_INFO_STRING]
+
+    extensions = %i[table tasklist strikethrough autolink tagfilter]
+
+    assert_equal "<p>Hello <strong>world</strong> – how are <em>you</em> today? I’m <del>fine</del>, ~yourself~?</p>\n", CommonMarker.render_doc(text, parse_opt, extensions).to_html
+
+    # note how tho the doc returned has sourcepos info, by default the renderer
+    # won't emit it. for that we need to pass in the render opt
+    assert_equal "<p data-sourcepos=\"1:1-1:65\">Hello <strong>world</strong> – how are <em>you</em> today? I’m <del>fine</del>, ~yourself~?</p>\n", CommonMarker.render_doc(text, parse_opt, extensions).to_html(render_opt, extensions)
+
+    assert_equal "<p data-sourcepos=\"1:1-1:65\">Hello <strong>world</strong> – how are <em>you</em> today? I’m <del>fine</del>, ~yourself~?</p>\n", CommonMarker.render_html(text, parse_opt, extensions)
+  end
 end

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -29,6 +29,9 @@ class TestExtensions < Minitest::Test
     doc = CommonMarker.render_doc('~a~ ~~b~~ ~~~c~~~', :STRIKETHROUGH_DOUBLE_TILDE, [:strikethrough])
     assert_equal("<p>~a~ <del>b</del> ~~~c~~~</p>\n", doc.to_html)
 
+    html = CommonMarker.render_html('~a~ ~~b~~ ~~~c~~~', :STRIKETHROUGH_DOUBLE_TILDE, [:strikethrough])
+    assert_equal("<p>~a~ <del>b</del> ~~~c~~~</p>\n", html)
+
     CommonMarker.render_html(@markdown, :DEFAULT, %i[table strikethrough]).tap do |out|
       refute_includes out, '| a'
       refute_includes out, '| <strong>x</strong>'

--- a/test/test_maliciousness.rb
+++ b/test/test_maliciousness.rb
@@ -67,11 +67,6 @@ module CommonMarker
         CommonMarker.render_html(nil)
       end
 
-      err = assert_raises TypeError do
-        CommonMarker.render_html("foo \n baz", [:SMART])
-      end
-      assert_equal('option \':SMART\' does not exist for CommonMarker::Config::OPTS[:render]', err.message)
-
       assert_raises TypeError do
         CommonMarker.render_doc("foo \n baz", 123)
       end

--- a/test/test_smartpunct.rb
+++ b/test/test_smartpunct.rb
@@ -7,11 +7,14 @@ class SmartPunctTest < Minitest::Test
 
   smart_punct.each do |testcase|
     doc = CommonMarker.render_doc(testcase[:markdown], :SMART)
+    html = CommonMarker.render_html(testcase[:markdown], :SMART)
 
     define_method("test_smart_punct_example_#{testcase[:example]}") do
-      actual = doc.to_html.strip
+      doc_rendered = doc.to_html.strip
+      html_rendered = html.strip
 
-      assert_equal testcase[:html], actual, testcase[:markdown]
+      assert_equal testcase[:html], doc_rendered, testcase[:markdown]
+      assert_equal testcase[:html], html_rendered, testcase[:markdown]
     end
   end
 


### PR DESCRIPTION
Hullo!

This PR "normalizes" the option bit mask flags that are made available as `parse` and `render` options respectively.

### Why?

When you use `CommonMarker.render_html` we load up `:render` options, and when you use `CommonMarker.render_doc` we load up `:parse` options. 

This makes sense; some options are only available to the html renderer, and it doesn't make sense to pass them down to the parser.

However, both `render_html` and `render_doc` initialize the parser with the provided options masked integer. Assuming that I'm looking at the right code, both [`rb_parse_document`](https://github.com/gjtorikian/commonmarker/blob/580f0fdac2a41042de1bbe3497487dcbfc5e20fe/ext/commonmarker/commonmarker.c#L308) and [`rb_markdown_to_html`](https://github.com/gjtorikian/commonmarker/blob/580f0fdac2a41042de1bbe3497487dcbfc5e20fe/ext/commonmarker/commonmarker.c#L159) take a `VALUE rb_options` and pass it directly on to `prepare_parser` ala

```
  parser = prepare_parser(rb_options, rb_extensions, $insert_allocator_here);
```

Consequently, I think every **parse** option should _also be available_ as a **render** option.

### How?

I looked up each individual flag, sorted them by the order in which they appear in `cmark-gfm.h`, and then grepped to see whether the option is checked inside a) `inlines.c` and `blocks.c` (parse) or b) if inside `html.c` or a relevant extension (render).

I then copied over all of the parse flags into the render hash and sorted them by the order in which they appear in `cmark-gfm.h`. I applied the same sorting to the README.

I have left comments accordingly tracing this. Hopefully this PR passes CI!

Cheers,