### PR TITLE
Fixup benchmark and speedup a little, fixes #141

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org/'
 gemspec
 
 group :benchmark do
+  gem 'benchmark-ips'
   gem 'kramdown'
   gem 'redcarpet'
 end

--- a/bin/commonmarker
+++ b/bin/commonmarker
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require 'optparse'
-require 'ostruct'
 
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'commonmarker'
@@ -11,16 +10,12 @@ root = File.expand_path('..', __dir__)
 $LOAD_PATH.unshift File.expand_path('lib', root)
 
 def parse_options
-  options = OpenStruct.new
+  options = Struct.new(:active_extensions, :active_parse_options, :active_render_options, :output_format, :renderer)
+                  .new([], [:DEFAULT], [:DEFAULT], :html)
   extensions = CommonMarker.extensions
   parse_options = CommonMarker::Config::OPTS.fetch(:parse)
   render_options = CommonMarker::Config::OPTS.fetch(:render)
   format_options = CommonMarker::Config::OPTS.fetch(:format)
-
-  options.active_extensions = []
-  options.active_parse_options = [:DEFAULT]
-  options.active_render_options = [:DEFAULT]
-  options.output_format = :html
 
   option_parser = OptionParser.new do |opts|
     opts.banner = 'Usage: commonmarker [--html-renderer] [--extension=EXTENSION]'

--- a/commonmarker.gemspec
+++ b/commonmarker.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib ext]
   s.required_ruby_version = ['>= 2.6', '< 4.0']
 
+  s.metadata['rubygems_mfa_required'] = 'true'
+
   s.rdoc_options += ['-x', 'ext/commonmarker/cmark/.*']
 
   s.add_development_dependency 'awesome_print'

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -154,19 +154,15 @@ static cmark_parser *prepare_parser(VALUE rb_options, VALUE rb_extensions) {
  *
  */
 static VALUE rb_markdown_to_html(VALUE self, VALUE rb_text, VALUE rb_options, VALUE rb_extensions) {
-  char *str, *html;
-  int len;
+  char *html;
   cmark_parser *parser;
   cmark_node *doc;
+
   Check_Type(rb_text, T_STRING);
-  Check_Type(rb_options, T_FIXNUM);
 
   parser = prepare_parser(rb_options, rb_extensions);
 
-  str = (char *)RSTRING_PTR(rb_text);
-  len = RSTRING_LEN(rb_text);
-
-  cmark_parser_feed(parser, str, len);
+  cmark_parser_feed(parser, StringValuePtr(rb_text), RSTRING_LEN(rb_text));
   doc = cmark_parser_finish(parser);
 
   if (doc == NULL) {
@@ -174,16 +170,12 @@ static VALUE rb_markdown_to_html(VALUE self, VALUE rb_text, VALUE rb_options, VA
     rb_raise(rb_eNodeError, "error parsing document");
   }
 
-  cmark_mem *default_mem = cmark_get_default_mem_allocator();
-  html = cmark_render_html_with_mem(doc, FIX2INT(rb_options), parser->syntax_extensions, default_mem);
+  html = cmark_render_html(doc, parser->options, parser->syntax_extensions);
 
   cmark_parser_free(parser);
   cmark_node_free(doc);
 
-  VALUE ruby_html = rb_str_new2(html);
-  default_mem->free(html);
-
-  return ruby_html;
+  return rb_utf8_str_new_cstr(html);
 }
 
 /*

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -183,33 +183,28 @@ static VALUE rb_markdown_to_html(VALUE self, VALUE rb_text, VALUE rb_options, VA
  *
  */
 static VALUE rb_markdown_to_xml(VALUE self, VALUE rb_text, VALUE rb_options, VALUE rb_extensions) {
-  char *str, *xml;
-  int len;
+  char *xml;
   cmark_parser *parser;
   cmark_node *doc;
+
   Check_Type(rb_text, T_STRING);
-  Check_Type(rb_options, T_FIXNUM);
 
   parser = prepare_parser(rb_options, rb_extensions);
 
-  str = (char *)RSTRING_PTR(rb_text);
-  len = RSTRING_LEN(rb_text);
-
-  cmark_parser_feed(parser, str, len);
+  cmark_parser_feed(parser, StringValuePtr(rb_text), RSTRING_LEN(rb_text));
   doc = cmark_parser_finish(parser);
+
   if (doc == NULL) {
     cmark_parser_free(parser);
     rb_raise(rb_eNodeError, "error parsing document");
   }
 
-  cmark_mem *default_mem = cmark_get_default_mem_allocator();
-  xml = cmark_render_xml_with_mem(doc, FIX2INT(rb_options), default_mem);
+  xml = cmark_render_xml(doc, parser->options);
+
   cmark_parser_free(parser);
+  cmark_node_free(doc);
 
-  VALUE ruby_xml = rb_str_new2(xml);
-  default_mem->free(xml);
-
-  return ruby_xml;
+  return rb_utf8_str_new_cstr(xml);
 }
 
 /*

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -295,7 +295,7 @@ static VALUE rb_node_new(VALUE self, VALUE type) {
 static VALUE rb_parse_document(VALUE self, VALUE rb_text, VALUE rb_len,
                                VALUE rb_options, VALUE rb_extensions) {
   char *text;
-  int len, options;
+  int len;
   cmark_parser *parser;
   cmark_node *doc;
   Check_Type(rb_text, T_STRING);
@@ -306,7 +306,6 @@ static VALUE rb_parse_document(VALUE self, VALUE rb_text, VALUE rb_len,
 
   text = (char *)RSTRING_PTR(rb_text);
   len = FIX2INT(rb_len);
-  options = FIX2INT(rb_options);
 
   cmark_parser_feed(parser, text, len);
   doc = cmark_parser_finish(parser);
@@ -601,7 +600,6 @@ static VALUE rb_render_html(VALUE self, VALUE rb_options, VALUE rb_extensions) {
  */
 static VALUE rb_render_xml(VALUE self, VALUE rb_options) {
   int options;
-  int i;
   cmark_node *node;
   Check_Type(rb_options, T_FIXNUM);
 

--- a/lib/commonmarker.rb
+++ b/lib/commonmarker.rb
@@ -23,9 +23,7 @@ module CommonMarker
     raise TypeError, "text must be a String; got a #{text.class}!" unless text.is_a?(String)
 
     opts = Config.process_options(options, :render)
-    text = text.encode('UTF-8')
-    html = Node.markdown_to_html(text, opts, extensions)
-    html.force_encoding('UTF-8')
+    Node.markdown_to_html(text.encode('UTF-8'), opts, extensions)
   end
 
   # Public: Parses a Markdown string into a `document` node.

--- a/test/benchmark.rb
+++ b/test/benchmark.rb
@@ -1,32 +1,39 @@
 # frozen_string_literal: true
 
+require 'benchmark/ips'
 require 'commonmarker'
-require 'github/markdown'
 require 'redcarpet'
 require 'kramdown'
 require 'benchmark'
 
-def dobench(name, &blk)
-  puts name
-  puts Benchmark.measure(&blk)
-end
+benchinput = File.read('test/benchinput.md').freeze
 
-benchinput = File.open('test/benchinput.md', 'r').read
+printf("input size = %<bytes>d bytes\n\n", { bytes: benchinput.bytesize })
 
-printf("input size = %<bytes>d bytes\n\n", benchinput.bytesize)
+Benchmark.ips do |x|
+  x.report('redcarpet') do
+    Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: false, tables: false).render(benchinput)
+  end
 
-dobench('redcarpet') do
-  Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: false, tables: false).render(benchinput)
-end
+  x.report('commonmarker with to_html') do
+    CommonMarker.render_html(benchinput)
+  end
 
-dobench('commonmarker with to_html') do
-  CommonMarker.render_html(benchinput)
-end
+  x.report('commonmarker with to_xml') do
+    CommonMarker.render_html(benchinput)
+  end
 
-dobench('commonmarker with ruby HtmlRenderer') do
-  CommonMarker::HtmlRenderer.new.render(CommonMarker.render_doc(benchinput))
-end
+  x.report('commonmarker with ruby HtmlRenderer') do
+    CommonMarker::HtmlRenderer.new.render(CommonMarker.render_doc(benchinput))
+  end
 
-dobench('kramdown') do
-  Kramdown::Document.new(benchinput).to_html(benchinput)
+  x.report('commonmarker with render_doc.to_html') do
+    CommonMarker.render_doc(benchinput, :DEFAULT, [:autolink]).to_html(:DEFAULT, [:autolink])
+  end
+
+  x.report('kramdown') do
+    Kramdown::Document.new(benchinput).to_html(benchinput)
+  end
+
+  x.compare!
 end


### PR DESCRIPTION
With README.md from this repo:
1ee03a81dcc922a3c75245a83e2f85f2a8593fe3 Fix benchmark, switch it to `benchmark-ips` and add xml + `Node#to_html`
```
input size = 9206 bytes

Warming up --------------------------------------
           redcarpet     1.998k i/100ms
commonmarker with to_html
                       652.000  i/100ms
commonmarker with to_xml
                       651.000  i/100ms
commonmarker with ruby HtmlRenderer
                       140.000  i/100ms
commonmarker with render_doc.to_html
                         1.021k i/100ms
            kramdown    17.000  i/100ms
Calculating -------------------------------------
           redcarpet     21.305k (± 1.5%) i/s -    107.892k in   5.065176s
commonmarker with to_html
                          6.127k (± 3.9%) i/s -     30.644k in   5.009868s
commonmarker with to_xml
                          5.775k (± 3.9%) i/s -     29.295k in   5.080767s
commonmarker with ruby HtmlRenderer
                          1.278k (± 6.1%) i/s -      6.440k in   5.057872s
commonmarker with render_doc.to_html
                          9.606k (±11.4%) i/s -     47.987k in   5.052644s
            kramdown    154.707  (± 5.8%) i/s -    782.000  in   5.075266s

Comparison:
           redcarpet:    21305.5 i/s
commonmarker with render_doc.to_html:     9606.0 i/s - 2.22x  (± 0.00) slower
commonmarker with to_html:     6126.7 i/s - 3.48x  (± 0.00) slower
commonmarker with to_xml:     5774.8 i/s - 3.69x  (± 0.00) slower
commonmarker with ruby HtmlRenderer:     1278.3 i/s - 16.67x  (± 0.00) slower
            kramdown:      154.7 i/s - 137.72x  (± 0.00) slower
```
272a7214254d1de9ffafffbf1b84d1b3139f222a Use default allocator for parser and rewrite creation a bit
```
input size = 9206 bytes

Warming up --------------------------------------
           redcarpet     1.915k i/100ms
commonmarker with to_html
                         1.197k i/100ms
commonmarker with to_xml
                         1.213k i/100ms
commonmarker with ruby HtmlRenderer
                       131.000  i/100ms
commonmarker with render_doc.to_html
                       989.000  i/100ms
            kramdown    16.000  i/100ms
Calculating -------------------------------------
           redcarpet     20.021k (± 1.7%) i/s -    101.495k in   5.070895s
commonmarker with to_html
                         11.790k (± 7.5%) i/s -     58.653k in   5.007325s
commonmarker with to_xml
                         11.386k (± 5.9%) i/s -     57.011k in   5.027840s
commonmarker with ruby HtmlRenderer
                          1.254k (± 5.8%) i/s -      6.288k in   5.036073s
commonmarker with render_doc.to_html
                          9.469k (±11.9%) i/s -     47.472k in   5.078444s
            kramdown    138.965  (±10.1%) i/s -    688.000  in   5.006044s

Comparison:
           redcarpet:    20021.4 i/s
commonmarker with to_html:    11789.7 i/s - 1.70x  (± 0.00) slower
commonmarker with to_xml:    11385.7 i/s - 1.76x  (± 0.00) slower
commonmarker with render_doc.to_html:     9468.7 i/s - 2.11x  (± 0.00) slower
commonmarker with ruby HtmlRenderer:     1254.0 i/s - 15.97x  (± 0.00) slower
            kramdown:      139.0 i/s - 144.08x  (± 0.00) slower
```
936e91017f65aaade3d5894d02623d1a1f816347 Rework rb_markdown_to_html
```
input size = 9206 bytes

Warming up --------------------------------------
           redcarpet     1.727k i/100ms
commonmarker with to_html
                         1.010k i/100ms
commonmarker with to_xml
                         1.050k i/100ms
commonmarker with ruby HtmlRenderer
                       115.000  i/100ms
commonmarker with render_doc.to_html
                       760.000  i/100ms
            kramdown    12.000  i/100ms
Calculating -------------------------------------
           redcarpet     16.851k (± 9.5%) i/s -     84.623k in   5.078071s
commonmarker with to_html
                         10.699k (± 4.0%) i/s -     53.530k in   5.011280s
commonmarker with to_xml
                         10.413k (± 4.0%) i/s -     52.500k in   5.050548s
commonmarker with ruby HtmlRenderer
                          1.134k (± 2.8%) i/s -      5.750k in   5.075396s
commonmarker with render_doc.to_html
                          8.896k (±11.2%) i/s -     44.080k in   5.023672s
            kramdown    145.532  (± 5.5%) i/s -    732.000  in   5.047857s

Comparison:
           redcarpet:    16851.2 i/s
commonmarker with to_html:    10699.4 i/s - 1.57x  (± 0.00) slower
commonmarker with to_xml:    10413.0 i/s - 1.62x  (± 0.00) slower
commonmarker with render_doc.to_html:     8896.2 i/s - 1.89x  (± 0.00) slower
commonmarker with ruby HtmlRenderer:     1133.9 i/s - 14.86x  (± 0.00) slower
            kramdown:      145.5 i/s - 115.79x  (± 0.00) slower
```
67f65d08057fd58be844a184043d586d3e8167a5 Rework rb_markdown_to_xml
```
input size = 9206 bytes

Warming up --------------------------------------
           redcarpet     1.714k i/100ms
commonmarker with to_html
                         1.018k i/100ms
commonmarker with to_xml
                         1.034k i/100ms
commonmarker with ruby HtmlRenderer
                       112.000  i/100ms
commonmarker with render_doc.to_html
                       750.000  i/100ms
            kramdown    14.000  i/100ms
Calculating -------------------------------------
           redcarpet     18.833k (± 2.9%) i/s -     94.270k in   5.010007s
commonmarker with to_html
                         11.402k (± 3.1%) i/s -     57.008k in   5.004576s
commonmarker with to_xml
                         11.328k (± 1.7%) i/s -     56.870k in   5.021896s
commonmarker with ruby HtmlRenderer
                          1.228k (± 2.7%) i/s -      6.160k in   5.020745s
commonmarker with render_doc.to_html
                          9.053k (±11.1%) i/s -     45.000k in   5.039098s
            kramdown    137.681  (±17.4%) i/s -    658.000  in   5.055183s

Comparison:
           redcarpet:    18832.8 i/s
commonmarker with to_html:    11402.2 i/s - 1.65x  (± 0.00) slower
commonmarker with to_xml:    11327.9 i/s - 1.66x  (± 0.00) slower
commonmarker with render_doc.to_html:     9052.8 i/s - 2.08x  (± 0.00) slower
commonmarker with ruby HtmlRenderer:     1227.8 i/s - 15.34x  (± 0.00) slower
            kramdown:      137.7 i/s - 136.79x  (± 0.00) slower
```