### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        ruby-version: [3.0.0, 2.7.2, 2.6.6]
+        ruby-version: [3.1, 3.0.0, 2.7.2, 2.6.6]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.