### PR TITLE
Add rb_undef_alloc_func for Node

### DIFF
--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -1255,6 +1255,7 @@ __attribute__((visibility("default"))) void Init_commonmarker() {
   rb_define_singleton_method(module, "extensions", rb_extensions, 0);
   rb_eNodeError = rb_define_class_under(module, "NodeError", rb_eStandardError);
   rb_cNode = rb_define_class_under(module, "Node", rb_cObject);
+  rb_undef_alloc_func(rb_cNode);
   rb_define_singleton_method(rb_cNode, "markdown_to_html", rb_markdown_to_html,
                              3);
   rb_define_singleton_method(rb_cNode, "markdown_to_xml", rb_markdown_to_xml,


### PR DESCRIPTION
This PR makes updates to allow this gem to work properly with Ruby 3.2.

The addition of the `rb_undef_alloc_func` calls ensures that we undefine allocate for T_DATA classes. This relates to a change in Ruby introduced here: https://github.com/ruby/ruby/pull/4604 (opened from [this issue](https://bugs.ruby-lang.org/issues/18007)).