### PR TITLE
[lets-rust] Get CI for Linux/macOS working

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,11 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # 'bundle install' and cache
 
+      - name: Set Cargo host triple
+        if: runner.os == 'Windows'
+        shell: bash
+        run: rustup set default-host x86_64-pc-windows-gnu
+
       - name: Run ${{ matrix.os }} tests
         shell: bash
         run: script/cibuild

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - lets-rust-where_r_u
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set Cargo host triple
         if: runner.os == 'Windows'
         shell: bash
-        run: rustup set default-host x86_64-pc-windows-gnu
+        run: rustup default stable-x86_64-pc-windows-gnu
 
       - name: Run ${{ matrix.os }} tests
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - lets-rust-where_r_u
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # 'bundle install' and cache
 
-      - name: Set Cargo host triple
+      - name: Set Cargo triple
         if: runner.os == 'Windows'
         shell: bash
         run: rustup default stable-x86_64-pc-windows-gnu

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -68,6 +68,7 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
     dir_config('commonmarker', HEADER_DIRS, LIB_DIRS)
   end
 
+  system "find ."
   recipe.activate
 
   $LIBS << ' -lcomrak_ffi'

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -51,11 +51,7 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
     recipe.download unless recipe.downloaded?
     recipe.extract
 
-    puts "tmp_path: #{recipe.send(:tmp_path)}"
-    system "find ."
     tarball_extract_path = File.join("tmp", recipe.host, "ports", recipe.name, recipe.version, "#{recipe.name}-#{recipe.version}")
-
-    # Why is this so long?
     Dir.chdir(tarball_extract_path) do
       puts `cargo build --manifest-path=./c-api/Cargo.toml --release`
     end
@@ -68,7 +64,6 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
     dir_config('commonmarker', HEADER_DIRS, LIB_DIRS)
   end
 
-  system "find ."
   recipe.activate
 
   $LIBS << ' -lcomrak_ffi'

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -22,7 +22,7 @@ ENV["CC"] = RbConfig::CONFIG["CC"]
 # be replaced with actual prepacked binaries.
 USER = "kivikakk"
 # COMRAK_VERSION = "0.14.0"
-COMRAK_VERSION = "c-api-staticlib"
+COMRAK_VERSION = "main"
 # TARBALL_URL = "https://github.com/#{USER}/comrak/archive/refs/tags/#{COMRAK_VERSION}.tar.gz"
 TARBALL_URL = "https://github.com/#{USER}/comrak/archive/refs/heads/#{COMRAK_VERSION}.tar.gz"
 
@@ -49,7 +49,11 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
 
     tarball_extract_path = File.join("tmp", recipe.host, "ports", recipe.name, recipe.version, "#{recipe.name}-#{recipe.version}")
     Dir.chdir(tarball_extract_path) do
-      puts `cargo build --manifest-path=./c-api/Cargo.toml --release`
+      system "cargo build --manifest-path=./c-api/Cargo.toml --release"
+
+      # We only want the static lib.
+      system "rm -f ./c-api/target/release/libcomrak_ffi.so"
+      system "rm -f ./c-api/target/release/libcomrak_ffi.dll"
     end
     lib_header_path = File.join(tarball_extract_path, "c-api", "include")
     lib_build_path = File.join(tarball_extract_path, "c-api", "target", "release")

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -62,7 +62,13 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
 
   recipe.activate
 
-  $LIBS << ' -lcomrak_ffi -lbcrypt'
+  $LIBS << ' -lcomrak_ffi'
+
+  if windows
+    # https://github.com/gjtorikian/commonmarker/runs/7686516209?check_suite_focus=true#step:5:299
+    # Not sure 100% why we need to link this ourselves.
+    $LIBS << ' -lbcrypt'
+  end
 end
 
 unless find_header("comrak_ffi.h")

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -67,12 +67,7 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
   recipe.activate
 
   $LIBS << ' -lcomrak_ffi'
-
-  if windows
-    # https://github.com/gjtorikian/commonmarker/runs/7686516209?check_suite_focus=true#step:5:299
-    # Not sure 100% why we need to link this ourselves.
-    $LIBS << ' -lbcrypt'
-  end
+  $LIBS << ' -lbcrypt' if windows
 end
 
 unless find_header("comrak_ffi.h")

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -51,6 +51,7 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
     recipe.download unless recipe.downloaded?
     recipe.extract
 
+    system "find #{GEM_ROOT_DIR}"
     tarball_extract_path = if darwin?
       recipe.host =~ /arm64-apple-darwin(\d+)\.\d+\.0/
       host = "arm64-darwin#{$1}"

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -51,9 +51,12 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
     Dir.chdir(tarball_extract_path) do
       system "cargo build --manifest-path=./c-api/Cargo.toml --release"
 
-      system "find ./c-api/target/release"
-      # We only want the static lib.
-      system "rm -f ./c-api/target/release/libcomrak_ffi.so"
+      # We only want libcomrak_ffi.a to remain.  libcomrak_ffi.so,
+      # libcomrak_ffi.dll.a (!) etc. are unwanted.
+      Dir["./c-api/target/release/libcomrak_ffi.*"].each do |f|
+        next if f.end_with?("/libcomrak_ffi.a")
+        system "rm", "-f", f
+      end
     end
     lib_header_path = File.join(tarball_extract_path, "c-api", "include")
     lib_build_path = File.join(tarball_extract_path, "c-api", "target", "release")

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -26,7 +26,7 @@ end
 # be replaced with actual prepacked binaries.
 USER = "kivikakk"
 # COMRAK_VERSION = "0.14.0"
-COMRAK_VERSION = "main"
+COMRAK_VERSION = "c-api-staticlib"
 # TARBALL_URL = "https://github.com/#{USER}/comrak/archive/refs/tags/#{COMRAK_VERSION}.tar.gz"
 TARBALL_URL = "https://github.com/#{USER}/comrak/archive/refs/heads/#{COMRAK_VERSION}.tar.gz"
 

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -53,13 +53,7 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
 
     puts "tmp_path: #{recipe.send(:tmp_path)}"
     system "find ."
-    tarball_extract_path = if darwin?
-      recipe.host =~ /arm64-apple-darwin(\d+)\.\d+\.0/
-      host = "arm64-darwin#{$1}"
-      File.join(GEM_ROOT_DIR, "tmp", host, "commonmarker", RUBY_VERSION, "tmp", recipe.host, "ports", recipe.name, recipe.version, "#{recipe.name}-#{recipe.version}")
-    else
-      File.join(GEM_ROOT_DIR, "tmp", recipe.host, "ports", recipe.name, recipe.version, "#{recipe.name}-#{recipe.version}")
-    end
+    tarball_extract_path = File.join("tmp", recipe.host, "ports", recipe.name, recipe.version, "#{recipe.name}-#{recipe.version}")
 
     # Why is this so long?
     Dir.chdir(tarball_extract_path) do

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -17,10 +17,6 @@ CROSS_BUILD_P = enable_config("cross-build")
 RbConfig::CONFIG["CC"] = RbConfig::MAKEFILE_CONFIG["CC"] = ENV["CC"] if ENV["CC"]
 ENV["CC"] = RbConfig::CONFIG["CC"]
 
-def darwin?
-  RbConfig::CONFIG["target_os"].include?("darwin")
-end
-
 # what follows is pretty much an abuse of miniportile2, but it works for now
 # i just need something to download files and run a cargo build; one day this should
 # be replaced with actual prepacked binaries.

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -51,7 +51,8 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
     recipe.download unless recipe.downloaded?
     recipe.extract
 
-    system "find #{GEM_ROOT_DIR}"
+    puts "tmp_path: #{recipe.send(:tmp_path)}"
+    system "find ."
     tarball_extract_path = if darwin?
       recipe.host =~ /arm64-apple-darwin(\d+)\.\d+\.0/
       host = "arm64-darwin#{$1}"

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -62,7 +62,7 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
 
   recipe.activate
 
-  $LIBS << ' -lcomrak_ffi'
+  $LIBS << ' -lcomrak_ffi -lbcrypt'
 end
 
 unless find_header("comrak_ffi.h")

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -51,12 +51,8 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
     Dir.chdir(tarball_extract_path) do
       system "cargo build --manifest-path=./c-api/Cargo.toml --release"
 
-      # We only want libcomrak_ffi.a to remain.  libcomrak_ffi.so,
-      # libcomrak_ffi.dll.a (!) etc. are unwanted.
-      Dir["./c-api/target/release/libcomrak_ffi.*"].each do |f|
-        next if f.end_with?("/libcomrak_ffi.a")
-        system "rm", "-f", f
-      end
+      system "rm -f ./c-api/target/release/libcomrak_ffi.so"
+      system "rm -f ./c-api/target/release/libcomrak_ffi.dll.a"
     end
     lib_header_path = File.join(tarball_extract_path, "c-api", "include")
     lib_build_path = File.join(tarball_extract_path, "c-api", "target", "release")

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -51,9 +51,9 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
     Dir.chdir(tarball_extract_path) do
       system "cargo build --manifest-path=./c-api/Cargo.toml --release"
 
+      system "find ./c-api/target/release"
       # We only want the static lib.
       system "rm -f ./c-api/target/release/libcomrak_ffi.so"
-      system "rm -f ./c-api/target/release/libcomrak_ffi.dll"
     end
     lib_header_path = File.join(tarball_extract_path, "c-api", "include")
     lib_build_path = File.join(tarball_extract_path, "c-api", "target", "release")

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -50,9 +50,6 @@ MiniPortile.new("comrak", COMRAK_VERSION).tap do |recipe|
     tarball_extract_path = File.join("tmp", recipe.host, "ports", recipe.name, recipe.version, "#{recipe.name}-#{recipe.version}")
     Dir.chdir(tarball_extract_path) do
       system "cargo build --manifest-path=./c-api/Cargo.toml --release"
-
-      system "rm -f ./c-api/target/release/libcomrak_ffi.so"
-      system "rm -f ./c-api/target/release/libcomrak_ffi.dll.a"
     end
     lib_header_path = File.join(tarball_extract_path, "c-api", "include")
     lib_build_path = File.join(tarball_extract_path, "c-api", "target", "release")


### PR DESCRIPTION
Was too curious and explored this messily. Still need to install dev tools on Windows or something?

The trick was:

1. not to `chdir`, just stay put wherever mini_portile puts us; and,
2. build comrak's `c-api` as a `staticlib` only; wasn't required for the Mac build to work (see 9565657 build logs), maybe the build prefers `.a` to `.dylib`, but on Linux it's like "hey where's my `libcomrak_ffi.so`".

If this looks good to you, I say we merge https://github.com/kivikakk/comrak/commit/c-api-staticlib and then squash this all into #185 (minus the branch name change).