### PR TITLE
Use docker-compiler to enable multiplatform builds

### DIFF
--- a/.cross_rubies
+++ b/.cross_rubies
@@ -1,0 +1,8 @@
+3.1.0:aarch64-linux
+3.1.0:arm-linux
+3.1.0:arm64-darwin
+3.1.0:x64-mingw-ucrt
+3.1.0:x86-linux
+3.1.0:x86-mingw32
+3.1.0:x86_64-darwin
+3.1.0:x86_64-linux

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: gjtorikian
+# patreon: gjtorikian
+# open_collective: garen-torikian
+#ko_fi: # Replace with a single Ko-fi username
+#tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+#community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+#liberapay: # Replace with a single Liberapay username
+# issuehunt: gjtorikian
+#otechie: # Replace with a single Otechie username
+#custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -1,0 +1,280 @@
+name: Test gem installation
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  rcd_image_version:
+    runs-on: ubuntu-latest
+    outputs:
+      rcd_image_version: ${{steps.rcd_image_version.outputs.rcd_image_version}}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+          bundler: latest
+      - id: rcd_image_version
+        run: bundle exec ruby -e 'require "rake_compiler_dock"; puts "::set-output name=rcd_image_version::#{RakeCompilerDock::IMAGE_VERSION}"'
+
+  cruby-package:
+    needs: ["rcd_image_version"]
+    name: "cruby-package"
+    runs-on: ubuntu-latest
+    container:
+      image: "larskanis/rake-compiler-dock-mri-x86_64-linux:${{needs.rcd_image_version.outputs.rcd_image_version}}"
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            /var/cache/apt/archives/
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ports/archives
+          key: tarballs-ubuntu-${{ hashFiles('dependencies.yml') }}
+
+      - run: ./script/test-gem-build gems ruby
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cruby-gem
+          path: gems
+          retention-days: 1
+
+  cruby-linux-install:
+    needs: ["cruby-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        sys: ["enable"]
+        ruby: ["3.1"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: ruby/setup-ruby-pkgs@v1
+        with:
+          ruby-version: "${{matrix.ruby}}"
+          apt-get: "pkg-config build-essential cargo"
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-gem
+          path: gems
+      - run: ./script/test-gem-install gems --${{matrix.sys}}-system-libraries
+
+  cruby-osx-install:
+    needs: ["cruby-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        sys: ["enable"]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-gem
+          path: gems
+      - run: ./script/test-gem-install gems --${{matrix.sys}}-system-libraries
+
+  cruby-windows-install-ucrt:
+    needs: ["cruby-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        sys: ["enable", "disable"]
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: ruby/setup-ruby-pkgs@v1
+        with:
+          ruby-version: "3.1"
+          mingw: "cargo"
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-gem
+          path: gems
+      - run: |
+          gem install --verbose --no-document gems/*.gem -- --${{matrix.sys}}-system-libraries
+          gem list -d commonmarker
+
+  cruby-native-package:
+    needs: ["rcd_image_version"]
+    name: "cruby-native-package"
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - "aarch64-linux"
+          - "arm-linux"
+          - "arm64-darwin"
+          - "x64-mingw-ucrt"
+          - "x86-linux"
+          - "x86-mingw32"
+          - "x86_64-darwin"
+          - "x86_64-linux"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ports/archives
+          key: tarballs-ubuntu-${{ hashFiles('dependencies.yml') }}
+
+      - run: |
+          docker run --rm -v "$(pwd):/commonmarker" -w /commonmarker \
+            larskanis/rake-compiler-dock-mri-${{matrix.platform}}:${{needs.rcd_image_version.outputs.rcd_image_version}} \
+            ./script/test-gem-build gems ${{matrix.platform}}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "cruby-${{matrix.platform}}-gem"
+          path: gems
+          retention-days: 1
+
+  cruby-x86-linux-install:
+    needs: ["cruby-native-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.1"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-x86-linux-gem
+          path: gems
+      - run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker run --rm -v "$(pwd):/commonmarker" -w /commonmarker \
+            --platform=linux/386 \
+            ruby:${{matrix.ruby}} \
+            ./script/test-gem-install gems
+
+  cruby-aarch64-linux-install:
+    needs: ["cruby-native-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.1"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-aarch64-linux-gem
+          path: gems
+      - run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker run --rm -v "$(pwd):/commonmarker" -w /commonmarker \
+            --platform=linux/arm64/v8 \
+            ruby:${{matrix.ruby}} \
+            ./script/test-gem-install gems
+
+  cruby-arm-linux-install:
+    needs: ["cruby-native-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.1"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-arm-linux-gem
+          path: gems
+      - run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker run --rm -v "$(pwd):/commonmarker" -w /commonmarker \
+            --platform=linux/arm/v7 \
+            ruby:${{matrix.ruby}} \
+            ./script/test-gem-install gems
+
+  cruby-x86_64-linux-install:
+    needs: ["cruby-native-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.1"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{matrix.ruby}}"
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-x86_64-linux-gem
+          path: gems
+      - run: ./script/test-gem-install gems
+
+  cruby-x86_64-darwin-install:
+    needs: ["cruby-native-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.1"]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{matrix.ruby}}"
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-x86_64-darwin-gem
+          path: gems
+      - run: ./script/test-gem-install gems
+
+  cruby-x64-mingw-ucrt-install:
+    needs: ["cruby-native-package"]
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.1"]
+    runs-on: windows-2022
+    steps:
+      - uses: ruby/setup-ruby-pkgs@v1
+        with:
+          ruby-version: "${{matrix.ruby}}"
+      - uses: actions/download-artifact@v2
+        with:
+          name: cruby-x64-mingw-ucrt-gem
+          path: gems
+      - run: |
+          gem install --verbose --no-document gems/*.gem
+          gem list -d commonmarker

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Linting
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true # 'bundle install' and cache
+      - name: Rubocop
+        run: bundle exec rake rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        ruby-version: [3.1]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # 'bundle install' and cache
+
+      - name: Set Cargo triple
+        if: runner.os == 'Windows'
+        shell: bash
+        run: rustup default stable-x86_64-pc-windows-gnu
+
+      - name: Run ${{ matrix.os }} tests
+        shell: bash
+        run: script/cibuild

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# bundler
+/.bundle/
+/Gemfile*lock
+/vendor/
+
+# building and packaging
+/ext/commonmarker/**/commonmarker.dll
+/ext/commonmarker/include
+/gems/
+/lib/commonmarker/**/commonmarker.bundle
+/lib/commonmarker/**/commonmarker.so
+/lib/commonmarker/commonmarker.jar
+/pkg/
+/ports/
+/tmp/
+commonmarker-*/**
+*.gem
+
+# code coverage
+/coverage/
+
+# documentation
+/html/
+
+# mac
+.DS_Store/
+
+# Vagrant
+/.vagrant/
+
+actual.txt
+test.txt
+test/progit
+test/benchinput.md
+
+.vscode
+rustup.sh
+/*.log

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+inherit_gem:
+  rubocop-standard:
+    - config/default.yml
+    - config/minitest.yml
+
+AllCops:
+  Exclude:
+    - "pkg/**/*"
+    - "ext/**/*"
+    - "vendor/**/*"
+    - "tmp/**/*"
+    - "test/progit/**/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,733 @@
+# Changelog
+
+## [v0.23.4](https://github.com/gjtorikian/commonmarker/tree/v0.23.4) (2022-03-03)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.23.2...v0.23.4)
+
+**Fixed bugs:**
+
+- `#render_html` way slower than `#render_doc.to_html` [\#141](https://github.com/gjtorikian/commonmarker/issues/141)
+
+**Closed issues:**
+
+- allow keeping text content of unknown tags [\#169](https://github.com/gjtorikian/commonmarker/issues/169)
+- STRIKETHROUGH\_DOUBLE\_TILDE not working [\#168](https://github.com/gjtorikian/commonmarker/issues/168)
+- Allow disabling 4-space code blocks [\#167](https://github.com/gjtorikian/commonmarker/issues/167)
+- tables with escaped pipes are not recognized [\#166](https://github.com/gjtorikian/commonmarker/issues/166)
+
+**Merged pull requests:**
+
+- CI: Drop a duplicate 'bundle install' [\#173](https://github.com/gjtorikian/commonmarker/pull/173) ([olleolleolle](https://github.com/olleolleolle))
+- CI: Drop duplicate bundle install [\#172](https://github.com/gjtorikian/commonmarker/pull/172) ([olleolleolle](https://github.com/olleolleolle))
+- Fixup benchmark and speedup a little, fixes \#141 [\#171](https://github.com/gjtorikian/commonmarker/pull/171) ([ojab](https://github.com/ojab))
+
+## [v0.23.2](https://github.com/gjtorikian/commonmarker/tree/v0.23.2) (2021-09-17)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.23.1...v0.23.2)
+
+**Merged pull requests:**
+
+- Update GFM release to `0.29.0.gfm.2` [\#148](https://github.com/gjtorikian/commonmarker/pull/148) ([phillmv](https://github.com/phillmv))
+
+## [v0.23.1](https://github.com/gjtorikian/commonmarker/tree/v0.23.1) (2021-09-03)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.23.0...v0.23.1)
+
+**Closed issues:**
+
+- Incorrect processing of list and next block of code [\#146](https://github.com/gjtorikian/commonmarker/issues/146)
+
+**Merged pull requests:**
+
+- Normalize parse and render options [\#145](https://github.com/gjtorikian/commonmarker/pull/145) ([phillmv](https://github.com/phillmv))
+
+## [v0.23.0](https://github.com/gjtorikian/commonmarker/tree/v0.23.0) (2021-08-30)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.22.0...v0.23.0)
+
+**Closed issues:**
+
+- Latest version of commonmarker breaks with jekyll build [\#142](https://github.com/gjtorikian/commonmarker/issues/142)
+
+**Merged pull requests:**
+
+- Add support for rendering XML from cmark-gfm [\#144](https://github.com/gjtorikian/commonmarker/pull/144) ([digitalmoksha](https://github.com/digitalmoksha))
+
+## [v0.22.0](https://github.com/gjtorikian/commonmarker/tree/v0.22.0) (2021-06-20)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.21.2...v0.22.0)
+
+**Closed issues:**
+
+- Recommendations on how to have autolink for phone numbers? [\#139](https://github.com/gjtorikian/commonmarker/issues/139)
+- Add option to disable indented code blocs [\#138](https://github.com/gjtorikian/commonmarker/issues/138)
+- Tagging "tasklist" lists with a class for easy styling? [\#137](https://github.com/gjtorikian/commonmarker/issues/137)
+- Escape math environments [\#136](https://github.com/gjtorikian/commonmarker/issues/136)
+- Open to removing the ruby-enum dependency? [\#135](https://github.com/gjtorikian/commonmarker/issues/135)
+- In HtmlRenderer, escape\_html\(\) returns a string with encoding \#\<Encoding:ASCII-8BIT\> [\#130](https://github.com/gjtorikian/commonmarker/issues/130)
+
+**Merged pull requests:**
+
+- Remove `ruby-enum` dependency [\#140](https://github.com/gjtorikian/commonmarker/pull/140) ([ojab](https://github.com/ojab))
+- Copy encoding when escaping hrefs/HTML [\#133](https://github.com/gjtorikian/commonmarker/pull/133) ([kivikakk](https://github.com/kivikakk))
+
+## [v0.21.2](https://github.com/gjtorikian/commonmarker/tree/v0.21.2) (2021-02-11)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.21.1...v0.21.2)
+
+**Closed issues:**
+
+- Potential to cut a new release? [\#129](https://github.com/gjtorikian/commonmarker/issues/129)
+
+**Merged pull requests:**
+
+- Switch to GitHub Actions [\#132](https://github.com/gjtorikian/commonmarker/pull/132) ([gjtorikian](https://github.com/gjtorikian))
+- Support :FOOTNOTES option for rendering HTML [\#131](https://github.com/gjtorikian/commonmarker/pull/131) ([aharpole](https://github.com/aharpole))
+
+## [v0.21.1](https://github.com/gjtorikian/commonmarker/tree/v0.21.1) (2021-01-21)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.21.0...v0.21.1)
+
+**Closed issues:**
+
+- Dependency error on new M1 Mac [\#128](https://github.com/gjtorikian/commonmarker/issues/128)
+- Inlines containing a pipe are not properly parsed within table rows [\#125](https://github.com/gjtorikian/commonmarker/issues/125)
+- Allow code snippets in multiple programming language [\#124](https://github.com/gjtorikian/commonmarker/issues/124)
+- Provide access to `refmap`. [\#121](https://github.com/gjtorikian/commonmarker/issues/121)
+- Numbered checklist [\#120](https://github.com/gjtorikian/commonmarker/issues/120)
+- Is there a specification for how URL slugs for headers are generated? [\#118](https://github.com/gjtorikian/commonmarker/issues/118)
+
+**Merged pull requests:**
+
+- Fix mismatched indentation [\#127](https://github.com/gjtorikian/commonmarker/pull/127) ([naoty](https://github.com/naoty))
+- Avoid a YARD annotation warning [\#119](https://github.com/gjtorikian/commonmarker/pull/119) ([olleolleolle](https://github.com/olleolleolle))
+
+## [v0.21.0](https://github.com/gjtorikian/commonmarker/tree/v0.21.0) (2020-01-23)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.20.2...v0.21.0)
+
+**Closed issues:**
+
+- Changelog [\#110](https://github.com/gjtorikian/commonmarker/issues/110)
+- Documentation out of date [\#109](https://github.com/gjtorikian/commonmarker/issues/109)
+
+**Merged pull requests:**
+
+- Add Node\#tasklist\_item\_checked= [\#116](https://github.com/gjtorikian/commonmarker/pull/116) ([tomoasleep](https://github.com/tomoasleep))
+- clear up an example in the README [\#115](https://github.com/gjtorikian/commonmarker/pull/115) ([kivikakk](https://github.com/kivikakk))
+- Update GFM release [\#113](https://github.com/gjtorikian/commonmarker/pull/113) ([gjtorikian](https://github.com/gjtorikian))
+- Rubocop updates [\#111](https://github.com/gjtorikian/commonmarker/pull/111) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.20.2](https://github.com/gjtorikian/commonmarker/tree/v0.20.2) (2019-12-18)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.20.1...v0.20.2)
+
+**Closed issues:**
+
+- Bug when parse word with spaces in tags [\#106](https://github.com/gjtorikian/commonmarker/issues/106)
+- UNSAFE mode inserts \<p\> tags inside \<pre\> tag [\#102](https://github.com/gjtorikian/commonmarker/issues/102)
+- Wrong path gets encoded in Makefile: /home/conda/feedstock\_root/build\_artifacts/ruby\_1552262701982/\_build\_env/bin/x86\_64-conda\_cos6-linux-gnu-cc: Command not found [\#101](https://github.com/gjtorikian/commonmarker/issues/101)
+
+**Merged pull requests:**
+
+- Add command line input for parse and render options [\#108](https://github.com/gjtorikian/commonmarker/pull/108) ([digitalmoksha](https://github.com/digitalmoksha))
+- Add tasklist extension description to README [\#103](https://github.com/gjtorikian/commonmarker/pull/103) ([tomoasleep](https://github.com/tomoasleep))
+
+## [v0.20.1](https://github.com/gjtorikian/commonmarker/tree/v0.20.1) (2019-04-29)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.20.0...v0.20.1)
+
+**Closed issues:**
+
+- 100mb test/benchinput.md file is included in published rubygem [\#99](https://github.com/gjtorikian/commonmarker/issues/99)
+
+**Merged pull requests:**
+
+- tasklist state inverted [\#100](https://github.com/gjtorikian/commonmarker/pull/100) ([kivikakk](https://github.com/kivikakk))
+
+## [v0.20.0](https://github.com/gjtorikian/commonmarker/tree/v0.20.0) (2019-04-09)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.19.0...v0.20.0)
+
+**Closed issues:**
+
+- Footnotes not working with autolink when its including "w" ? [\#95](https://github.com/gjtorikian/commonmarker/issues/95)
+
+**Merged pull requests:**
+
+- update to cmark-gfm 0.29.0.gfm.0 [\#98](https://github.com/gjtorikian/commonmarker/pull/98) ([kivikakk](https://github.com/kivikakk))
+
+## [v0.19.0](https://github.com/gjtorikian/commonmarker/tree/v0.19.0) (2019-04-03)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.18.2...v0.19.0)
+
+**Closed issues:**
+
+- .render\_html throws an error when given a parse-only option such as :SMART [\#96](https://github.com/gjtorikian/commonmarker/issues/96)
+- code in header produce invalid anchor [\#93](https://github.com/gjtorikian/commonmarker/issues/93)
+- Escaping of square brackets for reference-style links [\#91](https://github.com/gjtorikian/commonmarker/issues/91)
+- Please add an option for accessible footnotes [\#89](https://github.com/gjtorikian/commonmarker/issues/89)
+- ISSUE [\#82](https://github.com/gjtorikian/commonmarker/issues/82)
+
+**Merged pull requests:**
+
+- Indicte the context of an option [\#97](https://github.com/gjtorikian/commonmarker/pull/97) ([gjtorikian](https://github.com/gjtorikian))
+- Bump dependencies to support tasklists [\#94](https://github.com/gjtorikian/commonmarker/pull/94) ([gjtorikian](https://github.com/gjtorikian))
+- Remove cmake dependency from Travis [\#92](https://github.com/gjtorikian/commonmarker/pull/92) ([gjtorikian](https://github.com/gjtorikian))
+- Fixes up whitespace problems introduced in \#87 [\#90](https://github.com/gjtorikian/commonmarker/pull/90) ([diachini](https://github.com/diachini))
+- GitHub is https by default [\#88](https://github.com/gjtorikian/commonmarker/pull/88) ([amatsuda](https://github.com/amatsuda))
+
+## [v0.18.2](https://github.com/gjtorikian/commonmarker/tree/v0.18.2) (2018-11-28)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.18.1...v0.18.2)
+
+**Closed issues:**
+
+- Request: Support for Description Lists [\#86](https://github.com/gjtorikian/commonmarker/issues/86)
+- Code block vanishes in latest with commonmarker-rouge [\#85](https://github.com/gjtorikian/commonmarker/issues/85)
+- Request : Image Size Issues [\#84](https://github.com/gjtorikian/commonmarker/issues/84)
+- 'stdlib.h' file not found [\#83](https://github.com/gjtorikian/commonmarker/issues/83)
+
+**Merged pull requests:**
+
+- Allow `:UNSAFE` option for parsing [\#87](https://github.com/gjtorikian/commonmarker/pull/87) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.18.1](https://github.com/gjtorikian/commonmarker/tree/v0.18.1) (2018-10-18)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.18.0...v0.18.1)
+
+## [v0.18.0](https://github.com/gjtorikian/commonmarker/tree/v0.18.0) (2018-10-17)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.17.13...v0.18.0)
+
+**Closed issues:**
+
+- Math engine support \($$ $$\) [\#80](https://github.com/gjtorikian/commonmarker/issues/80)
+
+**Merged pull requests:**
+
+- Latest upstream [\#81](https://github.com/gjtorikian/commonmarker/pull/81) ([kivikakk](https://github.com/kivikakk))
+
+## [v0.17.13](https://github.com/gjtorikian/commonmarker/tree/v0.17.13) (2018-09-10)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.17.12...v0.17.13)
+
+**Merged pull requests:**
+
+- bump to cmark-gfm 0.28.3.gfm.16 [\#79](https://github.com/gjtorikian/commonmarker/pull/79) ([kivikakk](https://github.com/kivikakk))
+
+## [v0.17.12](https://github.com/gjtorikian/commonmarker/tree/v0.17.12) (2018-09-07)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.17.11...v0.17.12)
+
+**Closed issues:**
+
+- Bump gem to latest cmark-gfm... [\#77](https://github.com/gjtorikian/commonmarker/issues/77)
+- Tag 0.17.10 and 0.17.11 [\#75](https://github.com/gjtorikian/commonmarker/issues/75)
+
+**Merged pull requests:**
+
+- Update cmark-upstream  [\#78](https://github.com/gjtorikian/commonmarker/pull/78) ([gjtorikian](https://github.com/gjtorikian))
+- grab header/define fixes [\#76](https://github.com/gjtorikian/commonmarker/pull/76) ([kivikakk](https://github.com/kivikakk))
+
+## [v0.17.11](https://github.com/gjtorikian/commonmarker/tree/v0.17.11) (2018-08-10)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.17.10...v0.17.11)
+
+**Closed issues:**
+
+- Parsing additional info string as meta data on \<pre\> tags [\#72](https://github.com/gjtorikian/commonmarker/issues/72)
+
+**Merged pull requests:**
+
+- Bring in plaintext strikethrough rendering fix [\#74](https://github.com/gjtorikian/commonmarker/pull/74) ([kivikakk](https://github.com/kivikakk))
+
+## [0.17.10](https://github.com/gjtorikian/commonmarker/tree/0.17.10) (2018-08-08)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.17.10...0.17.10)
+
+## [v0.17.10](https://github.com/gjtorikian/commonmarker/tree/v0.17.10) (2018-08-08)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.17.9...v0.17.10)
+
+**Closed issues:**
+
+- Unable to install commonmarker on OS X [\#71](https://github.com/gjtorikian/commonmarker/issues/71)
+
+**Merged pull requests:**
+
+- --full-info-string [\#73](https://github.com/gjtorikian/commonmarker/pull/73) ([kivikakk](https://github.com/kivikakk))
+
+## [v0.17.9](https://github.com/gjtorikian/commonmarker/tree/v0.17.9) (2018-03-12)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.17.8...v0.17.9)
+
+**Closed issues:**
+
+- Failed to build gem native extension/ no rule to make target [\#67](https://github.com/gjtorikian/commonmarker/issues/67)
+
+**Merged pull requests:**
+
+- Remove square brackets when rendering HTML for footnotes [\#69](https://github.com/gjtorikian/commonmarker/pull/69) ([pyrmont](https://github.com/pyrmont))
+- Update both parse and render options in README [\#68](https://github.com/gjtorikian/commonmarker/pull/68) ([blackst0ne](https://github.com/blackst0ne))
+
+## [v0.17.8](https://github.com/gjtorikian/commonmarker/tree/v0.17.8) (2018-02-21)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.17.7.1...v0.17.8)
+
+**Closed issues:**
+
+- extension tasklist not found [\#64](https://github.com/gjtorikian/commonmarker/issues/64)
+- Request: mermaid rendering support within markdown [\#63](https://github.com/gjtorikian/commonmarker/issues/63)
+- Installation / make error in windows 10 [\#62](https://github.com/gjtorikian/commonmarker/issues/62)
+- Permissions error when installing on Windows 7 machine [\#61](https://github.com/gjtorikian/commonmarker/issues/61)
+
+**Merged pull requests:**
+
+- Support the TABLE\_PREFER\_STYLE\_ATTRIBUTES render option [\#66](https://github.com/gjtorikian/commonmarker/pull/66) ([gfx](https://github.com/gfx))
+- Fix issues with tables during a round-trip parsing CM and then producing CM again. [\#65](https://github.com/gjtorikian/commonmarker/pull/65) ([jerryjvl](https://github.com/jerryjvl))
+
+## [v0.17.7.1](https://github.com/gjtorikian/commonmarker/tree/v0.17.7.1) (2017-12-10)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.17.7...v0.17.7.1)
+
+**Closed issues:**
+
+- 0.17.6 install fails [\#59](https://github.com/gjtorikian/commonmarker/issues/59)
+
+## [v0.17.7](https://github.com/gjtorikian/commonmarker/tree/v0.17.7) (2017-12-05)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.17.6...v0.17.7)
+
+**Closed issues:**
+
+- Bump cmark-gfm to get support of footnotes [\#58](https://github.com/gjtorikian/commonmarker/issues/58)
+
+**Merged pull requests:**
+
+- No cmake required! [\#60](https://github.com/gjtorikian/commonmarker/pull/60) ([kivikakk](https://github.com/kivikakk))
+
+## [v0.17.6](https://github.com/gjtorikian/commonmarker/tree/v0.17.6) (2017-11-16)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.17.5...v0.17.6)
+
+## [v0.17.5](https://github.com/gjtorikian/commonmarker/tree/v0.17.5) (2017-10-19)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.17.4...v0.17.5)
+
+**Closed issues:**
+
+- \<tbody\> is missed on rendering doc [\#56](https://github.com/gjtorikian/commonmarker/issues/56)
+- Bold link in italics followed by a period [\#53](https://github.com/gjtorikian/commonmarker/issues/53)
+- Extensions are not documented [\#52](https://github.com/gjtorikian/commonmarker/issues/52)
+
+**Merged pull requests:**
+
+- Reset `needs_close_tbody` when entering tables [\#57](https://github.com/gjtorikian/commonmarker/pull/57) ([gjtorikian](https://github.com/gjtorikian))
+- Link to libcmark-gfm [\#55](https://github.com/gjtorikian/commonmarker/pull/55) ([kivikakk](https://github.com/kivikakk))
+- Document the extensions in the README [\#54](https://github.com/gjtorikian/commonmarker/pull/54) ([gjtorikian](https://github.com/gjtorikian))
+
+## [0.17.4](https://github.com/gjtorikian/commonmarker/tree/0.17.4) (2017-10-03)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.17.3...0.17.4)
+
+## [0.17.3](https://github.com/gjtorikian/commonmarker/tree/0.17.3) (2017-09-11)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.17.2...0.17.3)
+
+## [0.17.2](https://github.com/gjtorikian/commonmarker/tree/0.17.2) (2017-09-08)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.17.1...0.17.2)
+
+## [0.17.1](https://github.com/gjtorikian/commonmarker/tree/0.17.1) (2017-09-06)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.17.0...0.17.1)
+
+## [0.17.0](https://github.com/gjtorikian/commonmarker/tree/0.17.0) (2017-08-25)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.16.9...0.17.0)
+
+## [0.16.9](https://github.com/gjtorikian/commonmarker/tree/0.16.9) (2017-08-17)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.16.8...0.16.9)
+
+**Closed issues:**
+
+- Deployment - Cannot bundle commonmarker due to cmake [\#50](https://github.com/gjtorikian/commonmarker/issues/50)
+
+**Merged pull requests:**
+
+- Update link to the CMark docs options [\#51](https://github.com/gjtorikian/commonmarker/pull/51) ([unRob](https://github.com/unRob))
+
+## [0.16.8](https://github.com/gjtorikian/commonmarker/tree/0.16.8) (2017-07-17)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.16.7...0.16.8)
+
+## [0.16.7](https://github.com/gjtorikian/commonmarker/tree/0.16.7) (2017-07-12)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.16.6...0.16.7)
+
+## [0.16.6](https://github.com/gjtorikian/commonmarker/tree/0.16.6) (2017-07-11)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.16.5...0.16.6)
+
+## [0.16.5](https://github.com/gjtorikian/commonmarker/tree/0.16.5) (2017-06-30)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.16.4...0.16.5)
+
+## [0.16.4](https://github.com/gjtorikian/commonmarker/tree/0.16.4) (2017-06-27)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.16.3...0.16.4)
+
+**Merged pull requests:**
+
+- Full support for options and extensions in HtmlRenderer [\#48](https://github.com/gjtorikian/commonmarker/pull/48) ([kivikakk](https://github.com/kivikakk))
+
+## [0.16.3](https://github.com/gjtorikian/commonmarker/tree/0.16.3) (2017-06-21)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.16.2...0.16.3)
+
+## [0.16.2](https://github.com/gjtorikian/commonmarker/tree/0.16.2) (2017-06-21)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/0.16.1...0.16.2)
+
+## [0.16.1](https://github.com/gjtorikian/commonmarker/tree/0.16.1) (2017-06-21)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.16.0...0.16.1)
+
+**Closed issues:**
+
+- Cannot bundle commonmarker due to cmake [\#47](https://github.com/gjtorikian/commonmarker/issues/47)
+
+## [v0.16.0](https://github.com/gjtorikian/commonmarker/tree/v0.16.0) (2017-05-08)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.15.0...v0.16.0)
+
+**Merged pull requests:**
+
+- Plaintext renderer support [\#46](https://github.com/gjtorikian/commonmarker/pull/46) ([kivikakk](https://github.com/kivikakk))
+- Drop the remaining cached gems from the project [\#45](https://github.com/gjtorikian/commonmarker/pull/45) ([Empact](https://github.com/Empact))
+
+## [v0.15.0](https://github.com/gjtorikian/commonmarker/tree/v0.15.0) (2017-04-22)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.16...v0.15.0)
+
+**Closed issues:**
+
+- Request: PrettyPrint support for CommonMarker::Node [\#42](https://github.com/gjtorikian/commonmarker/issues/42)
+
+**Merged pull requests:**
+
+- support p and pp for CommonMarker::Node [\#44](https://github.com/gjtorikian/commonmarker/pull/44) ([gfx](https://github.com/gfx))
+- Fix a typo [\#43](https://github.com/gjtorikian/commonmarker/pull/43) ([muan](https://github.com/muan))
+
+## [v0.14.16](https://github.com/gjtorikian/commonmarker/tree/v0.14.16) (2017-04-04)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.15...v0.14.16)
+
+**Closed issues:**
+
+- Github/CommonMarker is parsing images/markup inconsistently. [\#41](https://github.com/gjtorikian/commonmarker/issues/41)
+- doc: contains corrupt UTF-8; thus gem does not install cleanly [\#40](https://github.com/gjtorikian/commonmarker/issues/40)
+
+## [v0.14.15](https://github.com/gjtorikian/commonmarker/tree/v0.14.15) (2017-04-03)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.14...v0.14.15)
+
+## [v0.14.14](https://github.com/gjtorikian/commonmarker/tree/v0.14.14) (2017-03-27)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.13...v0.14.14)
+
+## [v0.14.13](https://github.com/gjtorikian/commonmarker/tree/v0.14.13) (2017-03-26)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.12...v0.14.13)
+
+**Closed issues:**
+
+- Encoding error [\#39](https://github.com/gjtorikian/commonmarker/issues/39)
+
+**Merged pull requests:**
+
+- Add Yuki [\#38](https://github.com/gjtorikian/commonmarker/pull/38) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.14.12](https://github.com/gjtorikian/commonmarker/tree/v0.14.12) (2017-03-22)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.11...v0.14.12)
+
+## [v0.14.11](https://github.com/gjtorikian/commonmarker/tree/v0.14.11) (2017-03-22)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.10...v0.14.11)
+
+## [v0.14.10](https://github.com/gjtorikian/commonmarker/tree/v0.14.10) (2017-03-21)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.9...v0.14.10)
+
+## [v0.14.9](https://github.com/gjtorikian/commonmarker/tree/v0.14.9) (2017-03-20)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.8...v0.14.9)
+
+**Closed issues:**
+
+- option ':default' does not exist for CommonMarker::Config::Render [\#37](https://github.com/gjtorikian/commonmarker/issues/37)
+
+## [v0.14.8](https://github.com/gjtorikian/commonmarker/tree/v0.14.8) (2017-03-15)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.7...v0.14.8)
+
+## [v0.14.7](https://github.com/gjtorikian/commonmarker/tree/v0.14.7) (2017-03-13)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.6...v0.14.7)
+
+## [v0.14.6](https://github.com/gjtorikian/commonmarker/tree/v0.14.6) (2017-03-13)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.5...v0.14.6)
+
+## [v0.14.5](https://github.com/gjtorikian/commonmarker/tree/v0.14.5) (2017-03-06)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.4...v0.14.5)
+
+**Closed issues:**
+
+- ruby-enum v0.7.1 breaks the gem [\#35](https://github.com/gjtorikian/commonmarker/issues/35)
+
+**Merged pull requests:**
+
+- Capitalize symbol names [\#36](https://github.com/gjtorikian/commonmarker/pull/36) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.14.4](https://github.com/gjtorikian/commonmarker/tree/v0.14.4) (2017-02-23)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.3...v0.14.4)
+
+**Closed issues:**
+
+- Table extension with HTML Renderer causes segfault [\#34](https://github.com/gjtorikian/commonmarker/issues/34)
+
+## [v0.14.3](https://github.com/gjtorikian/commonmarker/tree/v0.14.3) (2017-02-06)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.2...v0.14.3)
+
+**Closed issues:**
+
+- Extensions disabled in IRB? [\#33](https://github.com/gjtorikian/commonmarker/issues/33)
+
+## [v0.14.2](https://github.com/gjtorikian/commonmarker/tree/v0.14.2) (2017-01-27)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.1...v0.14.2)
+
+## [v0.14.1](https://github.com/gjtorikian/commonmarker/tree/v0.14.1) (2017-01-23)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.14.0...v0.14.1)
+
+## [v0.14.0](https://github.com/gjtorikian/commonmarker/tree/v0.14.0) (2016-12-13)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.13.0...v0.14.0)
+
+**Merged pull requests:**
+
+- Extensions targetting github/cmark [\#32](https://github.com/gjtorikian/commonmarker/pull/32) ([kivikakk](https://github.com/kivikakk))
+
+## [v0.13.0](https://github.com/gjtorikian/commonmarker/tree/v0.13.0) (2016-11-27)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.12.0...v0.13.0)
+
+**Closed issues:**
+
+- `node.string_content` is not utf-8 [\#30](https://github.com/gjtorikian/commonmarker/issues/30)
+
+**Merged pull requests:**
+
+- Update cmark to 0.27.1 [\#31](https://github.com/gjtorikian/commonmarker/pull/31) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.12.0](https://github.com/gjtorikian/commonmarker/tree/v0.12.0) (2016-10-11)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.11.0...v0.12.0)
+
+**Merged pull requests:**
+
+- Revert "cmark extensions" [\#29](https://github.com/gjtorikian/commonmarker/pull/29) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.11.0](https://github.com/gjtorikian/commonmarker/tree/v0.11.0) (2016-09-18)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.10.0...v0.11.0)
+
+**Closed issues:**
+
+- No rule to make target libcmark\_static [\#22](https://github.com/gjtorikian/commonmarker/issues/22)
+
+**Merged pull requests:**
+
+- cmark extensions [\#28](https://github.com/gjtorikian/commonmarker/pull/28) ([kivikakk](https://github.com/kivikakk))
+
+## [v0.10.0](https://github.com/gjtorikian/commonmarker/tree/v0.10.0) (2016-07-21)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.9.2...v0.10.0)
+
+**Merged pull requests:**
+
+- Update cmark to https://github.com/jgm/cmark/commit/e91dc12128b156f1b… [\#27](https://github.com/gjtorikian/commonmarker/pull/27) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.9.2](https://github.com/gjtorikian/commonmarker/tree/v0.9.2) (2016-06-07)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.9.1...v0.9.2)
+
+**Closed issues:**
+
+- Using render options with a custom renderer [\#25](https://github.com/gjtorikian/commonmarker/issues/25)
+
+**Merged pull requests:**
+
+- Get memory magic [\#26](https://github.com/gjtorikian/commonmarker/pull/26) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.9.1](https://github.com/gjtorikian/commonmarker/tree/v0.9.1) (2016-05-24)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.9.0...v0.9.1)
+
+## [v0.9.0](https://github.com/gjtorikian/commonmarker/tree/v0.9.0) (2016-05-18)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.8.0...v0.9.0)
+
+**Closed issues:**
+
+- Make `Node` an `Enumerable` so that it can iterate over its children [\#23](https://github.com/gjtorikian/commonmarker/issues/23)
+
+**Merged pull requests:**
+
+- Make `Node` an `Enumerable` [\#24](https://github.com/gjtorikian/commonmarker/pull/24) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.8.0](https://github.com/gjtorikian/commonmarker/tree/v0.8.0) (2016-04-04)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.7.0...v0.8.0)
+
+**Merged pull requests:**
+
+- Update cmark to 0.25.2 [\#21](https://github.com/gjtorikian/commonmarker/pull/21) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.7.0](https://github.com/gjtorikian/commonmarker/tree/v0.7.0) (2016-01-20)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.6.0...v0.7.0)
+
+**Merged pull requests:**
+
+- Bump to 0.24 [\#20](https://github.com/gjtorikian/commonmarker/pull/20) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.6.0](https://github.com/gjtorikian/commonmarker/tree/v0.6.0) (2016-01-05)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.5.1...v0.6.0)
+
+**Merged pull requests:**
+
+- Update cmark to 0.23 [\#19](https://github.com/gjtorikian/commonmarker/pull/19) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.5.1](https://github.com/gjtorikian/commonmarker/tree/v0.5.1) (2015-11-04)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.5.0...v0.5.1)
+
+**Closed issues:**
+
+- Smart punctuation and hardbreaks don't mix in render\_doc [\#17](https://github.com/gjtorikian/commonmarker/issues/17)
+
+**Merged pull requests:**
+
+- Mix and match options [\#18](https://github.com/gjtorikian/commonmarker/pull/18) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.5.0](https://github.com/gjtorikian/commonmarker/tree/v0.5.0) (2015-09-25)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.4.1...v0.5.0)
+
+**Closed issues:**
+
+- Direct access to sourcepos on the Node [\#15](https://github.com/gjtorikian/commonmarker/issues/15)
+
+**Merged pull requests:**
+
+- Add `sourcepos` information [\#16](https://github.com/gjtorikian/commonmarker/pull/16) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.4.1](https://github.com/gjtorikian/commonmarker/tree/v0.4.1) (2015-08-26)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.4.0...v0.4.1)
+
+**Closed issues:**
+
+- libcmark is missing [\#13](https://github.com/gjtorikian/commonmarker/issues/13)
+
+**Merged pull requests:**
+
+- Don't perform `find_library` on OS X's system Ruby [\#14](https://github.com/gjtorikian/commonmarker/pull/14) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.4.0](https://github.com/gjtorikian/commonmarker/tree/v0.4.0) (2015-08-24)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.3.0...v0.4.0)
+
+**Merged pull requests:**
+
+- Update cmark to 1f4632b8e761da5aaeebcefb2e43332ad267dba8 [\#12](https://github.com/gjtorikian/commonmarker/pull/12) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.3.0](https://github.com/gjtorikian/commonmarker/tree/v0.3.0) (2015-07-20)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.2.1...v0.3.0)
+
+**Merged pull requests:**
+
+- Bump cmark@0.21.0 [\#11](https://github.com/gjtorikian/commonmarker/pull/11) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.2.1](https://github.com/gjtorikian/commonmarker/tree/v0.2.1) (2015-07-07)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.2.0...v0.2.1)
+
+**Closed issues:**
+
+- Error "incompatible character encodings: UTF-8 and ASCII-8BIT" when combined with a rails app [\#9](https://github.com/gjtorikian/commonmarker/issues/9)
+
+**Merged pull requests:**
+
+- UTF-8 issues [\#10](https://github.com/gjtorikian/commonmarker/pull/10) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.2.0](https://github.com/gjtorikian/commonmarker/tree/v0.2.0) (2015-06-26)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.1.3...v0.2.0)
+
+**Closed issues:**
+
+- Test all the tests/options in CMark [\#6](https://github.com/gjtorikian/commonmarker/issues/6)
+
+**Merged pull requests:**
+
+- Implement Node class in C, fix memory management [\#8](https://github.com/gjtorikian/commonmarker/pull/8) ([nwellnhof](https://github.com/nwellnhof))
+- More testing [\#7](https://github.com/gjtorikian/commonmarker/pull/7) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.1.3](https://github.com/gjtorikian/commonmarker/tree/v0.1.3) (2015-05-27)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.1.2...v0.1.3)
+
+**Closed issues:**
+
+- Look into using the C AST walk  [\#3](https://github.com/gjtorikian/commonmarker/issues/3)
+- Don't force users to call `free`, if possible [\#2](https://github.com/gjtorikian/commonmarker/issues/2)
+
+**Merged pull requests:**
+
+- Better memory management [\#5](https://github.com/gjtorikian/commonmarker/pull/5) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.1.2](https://github.com/gjtorikian/commonmarker/tree/v0.1.2) (2015-05-14)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.1.1...v0.1.2)
+
+## [v0.1.1](https://github.com/gjtorikian/commonmarker/tree/v0.1.1) (2015-05-14)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.1.0...v0.1.1)
+
+## [v0.1.0](https://github.com/gjtorikian/commonmarker/tree/v0.1.0) (2015-05-13)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/v0.0.1...v0.1.0)
+
+**Merged pull requests:**
+
+- Start wrapping C in Ruby [\#1](https://github.com/gjtorikian/commonmarker/pull/1) ([gjtorikian](https://github.com/gjtorikian))
+
+## [v0.0.1](https://github.com/gjtorikian/commonmarker/tree/v0.0.1) (2015-05-10)
+
+[Full Changelog](https://github.com/gjtorikian/commonmarker/compare/963ec7e72ff5125b11b3fbc842bd077031fc6c90...v0.0.1)
+
+
+
+\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*

--- a/CODE_OF_CONDUCT.txt
+++ b/CODE_OF_CONDUCT.txt
@@ -1,0 +1,87 @@
+Contributor Covenant Code of Conduct
+
+Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+
+Examples of unacceptable behavior include:
+
+
+* The use of sexualized language or imagery, and sexual attention or
+advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or email
+address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+professional setting
+
+
+Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at gjtorikian@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1. Correction
+
+Community Impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+2. Warning
+
+Community Impact: A violation through a single incident or series of actions.
+
+Consequence: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+3. Temporary Ban
+
+Community Impact: A serious violation of community standards, including sustained inappropriate behavior.
+
+Consequence: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+4. Permanent Ban
+
+Community Impact: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+Consequence: A permanent ban from any sort of public interaction within the community.
+
+Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.0,
+available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by Mozilla’s code of conduct enforcement ladder.
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org/"
+
+gemspec
+
+group :debug do
+  gem "awesome_print"
+  gem "debug"
+end
+
+group :test do
+  gem "minitest", "~> 5.6"
+  gem "minitest-focus", "~> 1.1"
+end
+
+group :lint do
+  gem "rubocop-standard"
+end
+
+group :benchmark do
+  gem "benchmark-ips"
+  gem "kramdown"
+  gem "kramdown-parser-gfm"
+  gem "redcarpet"
+end

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2015 Garen J. Torikian
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,134 @@
+# CommonMarker
+
+![Build Status](https://github.com/gjtorikian/commonmarker/workflows/CI/badge.svg) [![Gem Version](https://badge.fury.io/rb/commonmarker.svg)](http://badge.fury.io/rb/commonmarker)
+
+Ruby wrapper for [libcmark-gfm](https://github.com/github/cmark),
+GitHub's fork of the reference parser for CommonMark. It passes all of the C tests, and is therefore spec-complete. It also includes extensions to the CommonMark spec as documented in the [GitHub Flavored Markdown spec](http://github.github.com/gfm/), such as support for tables, strikethroughs, and autolinking.
+
+For more information on available extensions, see [the documentation below](#extensions).
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'commonmarker'
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install commonmarker
+
+## Usage
+
+### Converting to HTML
+
+Call `render_html` on a string to convert it to HTML:
+
+``` ruby
+require 'commonmarker'
+CommonMarker.to_html('Hi *there*', :DEFAULT)
+# <p>Hi <em>there</em></p>\n
+```
+
+The second argument is optional--[see below](#options) for more information.
+
+## Options
+
+CommonMarker accepts the same options that CMark does, as symbols. Note that there is a distinction in CMark for "parse" options and "render" options, which are represented in the tables below.
+
+### Parse options
+
+| Name                          | Description
+| ----------------------------- | -----------
+| `:DEFAULT`                    | The default parsing system.
+| `:SOURCEPOS`                  | Include source position in nodes
+| `:UNSAFE`                     | Allow raw/custom HTML and unsafe links.
+| `:VALIDATE_UTF8`              | Replace illegal sequences with the replacement character `U+FFFD`.
+| `:SMART`                      | Use smart punctuation (curly quotes, etc.).
+| `:LIBERAL_HTML_TAG`           | Support liberal parsing of inline HTML tags.
+| `:FOOTNOTES`                  | Parse footnotes.
+| `:STRIKETHROUGH_DOUBLE_TILDE` | Parse strikethroughs by double tildes (compatibility with [redcarpet](https://github.com/vmg/redcarpet))
+
+### Render options
+
+| Name                             | Description                                                     |
+| ------------------               | -----------                                                     |
+| `:DEFAULT`                       | The default rendering system.                                   |
+| `:SOURCEPOS`                     | Include source position in rendered HTML.                       |
+| `:HARDBREAKS`                    | Treat `\n` as hardbreaks (by adding `<br/>`).                   |
+| `:UNSAFE`                        | Allow raw/custom HTML and unsafe links.                         |
+| `:NOBREAKS`                      | Translate `\n` in the source to a single whitespace.            |
+| `:VALIDATE_UTF8`                 | Replace illegal sequences with the replacement character `U+FFFD`. |
+| `:SMART`                         | Use smart punctuation (curly quotes, etc.).                     |
+| `:GITHUB_PRE_LANG`               | Use GitHub-style `<pre lang>` for fenced code blocks.           |
+| `:LIBERAL_HTML_TAG`              | Support liberal parsing of inline HTML tags.                    |
+| `:FOOTNOTES`                     | Render footnotes.                                               |
+| `:STRIKETHROUGH_DOUBLE_TILDE`    | Parse strikethroughs by double tildes (compatibility with [redcarpet](https://github.com/vmg/redcarpet)) |
+| `:TABLE_PREFER_STYLE_ATTRIBUTES` | Use `style` insted of `align` for table cells.                  |
+| `:FULL_INFO_STRING`              | Include full info strings of code blocks in separate attribute. |
+
+### Passing options
+
+To apply an option, pass it as part of the hash:
+
+``` ruby
+CommonMarker.to_html("\"Hello,\" said the spider.", :SMART)
+# <p>“Hello,” said the spider.</p>\n
+
+CommonMarker.to_html("\"'Shelob' is my name.\"", [:HARDBREAKS, :SOURCEPOS])
+```
+
+For more information on these options, see [the comrak documentation](https://github.com/kivikakk/comrak#usage).
+
+## Output formats
+
+Commonmarker can only generate output in one format: HTML.
+
+### HTML
+
+```ruby
+html = CommonMarker.to_html('*Hello* world!', :DEFAULT)
+puts(html)
+
+# <p><em>Hello</em> world!</p>
+```
+
+## Developing locally
+
+After cloning the repo:
+
+```
+script/bootstrap
+bundle exec rake compile
+```
+
+If there were no errors, you're done! Otherwise, make sure to follow the comrak dependency instructions.
+
+## Benchmarks
+
+Some rough benchmarks:
+
+```
+$ bundle exec rake benchmark
+
+input size = 11064832 bytes
+
+Warming up --------------------------------------
+           redcarpet     2.000  i/100ms
+commonmarker with to_html
+                         1.000  i/100ms
+            kramdown     1.000  i/100ms
+Calculating -------------------------------------
+           redcarpet     22.634  (± 4.4%) i/s -    114.000  in   5.054490s
+commonmarker with to_html
+                          7.340  (± 0.0%) i/s -     37.000  in   5.058352s
+            kramdown      0.343  (± 0.0%) i/s -      2.000  in   5.834208s
+
+Comparison:
+           redcarpet:       22.6 i/s
+commonmarker with to_html:        7.3 i/s - 3.08x  (± 0.00) slower
+            kramdown:        0.3 i/s - 66.02x  (± 0.00) slower
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Gem Spec
+require "bundler"
+COMMONMARKER_SPEC = Bundler.load_gemspec("commonmarker.gemspec")
+
+# Packaging
+require "bundler/gem_tasks"

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "commonmarker"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/commonmarker.gemspec
+++ b/commonmarker.gemspec
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "commonmarker/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "commonmarker"
+  spec.version = Commonmarker::VERSION
+  spec.summary = "CommonMark parser and renderer. Written in Rust, wrapped in Ruby."
+  spec.description = "A fast, safe, extensible parser for CommonMark. This wraps the comrak Rust crate."
+  spec.authors = ["Garen Torikian", "Ashe Connor"]
+  spec.homepage = "https://github.com/gjtorikian/commonmarker"
+  spec.license = "MIT"
+
+  spec.files = [
+    "Gemfile",
+    "LICENSE.txt",
+    "README.md",
+    "dependencies.yml",
+    "ext/commonmarker/commonmarker.h",
+    "ext/commonmarker/commonmarker.c",
+  ]
+  spec.files += Dir.glob("lib/**/*.rb")
+  spec.extensions << "ext/commonmarker/extconf.rb"
+
+  spec.required_ruby_version = [">= 3.1", "< 4.0"]
+
+  spec.metadata = {
+    "funding_uri" => "https://github.com/sponsors/gjtorikian/",
+    "rubygems_mfa_required" => "true",
+  }
+
+  spec.add_development_dependency("rake", "~> 13.0")
+  spec.add_development_dependency("rake-compiler", "~> 1.0")
+  spec.add_development_dependency("rake-compiler-dock", "~> 1.2")
+  spec.add_development_dependency("rdoc", "~> 6.2")
+
+  spec.add_runtime_dependency("mini_portile2", "~> 2.8") # keep version in sync with extconf.rb
+end

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,0 +1,5 @@
+comrak:
+  repo: kivikakk/comrak
+  path: refs/tags
+  version: 64d031bcb1230aea9413791653d3760ac7a4316a
+  sha256: f773560ce68ad7c4a8456b0c9949632d466737b3a076b43d413b6f4c0032d80b

--- a/ext/commonmarker/_cflags.rb
+++ b/ext/commonmarker/_cflags.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# adopt environment config
+append_cflags(ENV["CFLAGS"].split) unless ENV["CFLAGS"].nil?
+append_cppflags(ENV["CPPFLAGS"].split) unless ENV["CPPFLAGS"].nil?
+append_ldflags(ENV["LDFLAGS"].split) unless ENV["LDFLAGS"].nil?
+$LIBS = concat_flags($LIBS, ENV.fetch("LIBS", nil)) # rubocop:disable Style/GlobalVars
+
+append_cflags(["-std=c11", "-Wno-declaration-after-statement"])
+
+# always include debugging information
+append_cflags("-g")
+
+# good to have no matter what Ruby was compiled with
+append_cflags("-Wmissing-noreturn")
+
+# handle clang variations, see nokogiri#1101
+append_cflags("-Wno-error=unused-command-line-argument-hard-error-in-future") if darwin?
+
+append_cflags("-Werror=incompatible-pointer-types")
+
+append_cflags(ci? || debug? ? "-O0" : "-O2")
+
+# Work around a character escaping bug in MSYS by passing an arbitrary double-quoted parameter to gcc.
+# See https://sourceforge.net/p/mingw/bugs/2142
+append_cppflags(' "-Idummypath"') if windows?
+
+if openbsd?
+  unless /clang/.match?(%x(#{ENV.fetch("CC", "/usr/bin/cc")} -v 2>&1))
+    (ENV["CC"] ||= find_executable("egcc")) ||
+      abort("Please install gcc 4.9+ from ports using `pkg_add -v gcc`")
+  end
+  append_cppflags("-I/usr/local/include")
+end

--- a/ext/commonmarker/_clean.rb
+++ b/ext/commonmarker/_clean.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+def do_clean
+  root = Pathname(PACKAGE_ROOT_DIR)
+  pwd  = Pathname(Dir.pwd)
+
+  # Skip if this is a development work tree
+  unless File.new(File.join(root, "git")).exist?
+    puts "Cleaning files only used during build."
+
+    # (root + 'tmp') cannot be removed at this stage because
+    # selma.so is yet to be copied to lib.
+
+    # clean the ports build directory
+    Pathname.glob(pwd.join("tmp", "*", "ports")) do |dir|
+      FileUtils.rm_rf(dir, verbose: true)
+    end
+
+    if config_static?
+      # ports installation can be safely removed if statically linked.
+      FileUtils.rm_rf("#{root}ports", verbose: true)
+    else
+      FileUtils.rm_rf("#{root}portsarchives", verbose: true)
+    end
+  end
+
+  exit!(0)
+end
+
+do_clean if arg_config("--clean")

--- a/ext/commonmarker/_comrak.rb
+++ b/ext/commonmarker/_comrak.rb
@@ -1,0 +1,181 @@
+require_relative "_dependencies"
+
+# what follows is pretty much an abuse of miniportile2, but it works
+# I just need something to download files and run a cargo build;
+# miniportile2 comes with sha checks and retries
+def make_mini_portile(name, version, repo:)
+  require "rubygems"
+  gem("mini_portile2", REQUIRED_MINI_PORTILE_VERSION) # gemspec is not respected at install time
+  require "mini_portile2"
+
+  MiniPortile.new(name, version, repo: repo).tap do |recipe|
+    def recipe.dependencies
+      raise "dependencies.yml not found at #{File.join(GEM_ROOT_DIR, "dependencies.yml")}" unless File.exist?(File.join(GEM_ROOT_DIR, "dependencies.yml"))
+
+      return @dependencies if defined?(@dependencies)
+      @dependencies = YAML.load_file(File.join(GEM_ROOT_DIR, "dependencies.yml"))
+    end
+
+    def recipe.dependency_sha256
+      dependencies[@name]["sha256"]
+    end
+
+    def recipe.files_hashs
+      files
+    end
+
+    def recipe.port_path
+      "#{@target}/#{RUBY_PLATFORM}/#{@name}/#{@version}"
+    end
+
+    def recipe.checkpoint
+      "#{@target}/#{@name}-#{@version}-#{RUBY_PLATFORM}.compiled"
+    end
+
+    def recipe.rename
+      curr_name = File.join(archive_path, "#{@version}.tar.gz")
+      new_name = File.join(archive_path, "#{@name}-#{@version}.tar.gz")
+
+      # could've been previously downloaded and never removed
+      # (rake clean leaves it alone)
+      return if File.exist?(new_name)
+
+      File.rename(curr_name, new_name)
+    end
+
+    def recipe.cargo_build(target: "")
+      commands = ["cargo", "build", "--manifest-path=./c-api/Cargo.toml", "--release"]
+
+      commands << "--target=#{target}" unless target.empty?
+
+      execute('cargo_build', commands)
+    end
+
+    def recipe.extracted_ffi_path
+      File.join(GEM_ROOT_DIR, "tmp", RUBY_PLATFORM, "commonmarker", RUBY_VERSION, tmp_path, "#{@name}-#{@version}", "c-api")
+    end
+
+    def recipe.archive_path
+      File.join(GEM_ROOT_DIR, "ports", "archives")
+    end
+
+    def recipe.output_path_from_ffi
+      File.join(extracted_ffi_path, "target", "release")
+    end
+
+    def recipe.output_path
+      File.join(path, "release")
+    end
+
+    def recipe.header_path_from_ffi
+      File.join(extracted_ffi_path, "include")
+    end
+
+    def recipe.header_path
+      File.join(path, "include")
+    end
+
+    def recipe.compiled?
+      cargo_toml  = File.join(extracted_ffi_path, 'Cargo.toml')
+
+      newer?(cargo_toml, checkpoint)
+    end
+
+    @repo = repo
+    recipe.target = File.join(GEM_ROOT_DIR, "ports")
+    recipe.host = RbConfig::CONFIG["host_alias"].empty? ? RbConfig::CONFIG["host"] : RbConfig::CONFIG["host_alias"]
+    recipe.configure_options << "--libdir=#{File.join(recipe.path, "lib")}"
+
+    env = Hash.new do |hash, key|
+      hash[key] = (ENV[key]).to_s
+    end
+
+    if config_static?
+      recipe.configure_options += [
+        "--disable-shared",
+        "--enable-static",
+      ]
+      env["CFLAGS"] = concat_flags(env["CFLAGS"], "-fPIC")
+    else
+      recipe.configure_options += [
+        "--enable-shared",
+        "--disable-static",
+      ]
+    end
+
+    if config_cross_build?
+      recipe.configure_options += [
+        "--target=#{recipe.host}",
+        "--host=#{recipe.host}",
+      ]
+    end
+
+    if RbConfig::CONFIG["target_cpu"] == "universal"
+      ["CFLAGS", "LDFLAGS"].each do |key|
+        unless env[key].include?("-arch")
+          env[key] = concat_flags(env[key], RbConfig::CONFIG["ARCH_FLAG"])
+        end
+      end
+    end
+
+    recipe.configure_options += env.map do |key, value|
+      "#{key}=#{value.strip}"
+    end
+
+    tarball_url = "https://github.com/#{@repo}/archive/#{recipe.version}.tar.gz"
+
+    recipe.files = [{
+      url: tarball_url,
+      local_path: File.join(recipe.archive_path, "#{recipe.name}-#{recipe.version}.tar.gz"),
+      sha256: recipe.dependency_sha256,
+    }]
+
+    checkpoint = "#{recipe.target}/#{recipe.name}-#{recipe.version}-#{RUBY_PLATFORM}.compiled"
+    if !File.exist?(checkpoint)
+      chdir_for_build do
+        puts "Downloading tarball from #{tarball_url} ..."
+        recipe.download unless recipe.downloaded?
+        recipe.rename
+        recipe.extract
+
+        # we want to target mingw, but rust gives msvc by default
+        target = if windows?
+                    x86_64? ? "x86_64-pc-windows-gnu" : "i686-pc-windows-gnu"
+                 else
+                    ""
+                 end
+
+        recipe.cargo_build(target: target) unless recipe.compiled?
+
+        FileUtils.rm_rf(recipe.path, secure: true)
+
+        FileUtils.touch(recipe.checkpoint)
+      end
+    else
+      puts "Checkpoint found at #{checkpoint}, skipping download and build"
+    end
+    FileUtils.mkdir_p(recipe.path)
+
+    # mingw insists on files not being present when copying
+    if File.exist?(recipe.extracted_ffi_path)
+      FileUtils.rm_rf(recipe.output_path, secure: true)
+      FileUtils.cp_r(recipe.output_path_from_ffi, recipe.output_path)
+
+      FileUtils.rm_rf(recipe.header_path, secure: true)
+      FileUtils.cp_r(recipe.header_path_from_ffi, recipe.header_path)
+
+      puts "Output files copied to #{recipe.path}"
+    end
+
+    recipe.activate
+  end
+end
+
+def build_comrak
+  dependency_name = "comrak"
+  dependency = DEPENDENCIES[dependency_name]
+  dependency_repo = dependency["repo"]
+  dependency_version = dependency["version"]
+
+  make_mini_portile(dependency_name, dependency_version, repo: dependency_repo)
+end

--- a/ext/commonmarker/_config.rb
+++ b/ext/commonmarker/_config.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+def debug?
+  ENV.fetch("DEBUG", false) || arg_config("--debug")
+end
+
+def ci?
+  ENV.fetch("CI", false)
+end
+
+def asan?
+  ENV.fetch("ASAN", false) || enable_config("asan")
+end
+
+def config_clean?
+  enable_config("clean", false)
+end
+
+def config_static?
+  enable_config("static", true)
+end
+
+def config_cross_build?
+  enable_config("cross-build")
+end

--- a/ext/commonmarker/_dependencies.rb
+++ b/ext/commonmarker/_dependencies.rb
@@ -1,0 +1,2 @@
+require "yaml"
+DEPENDENCIES = YAML.load_file(File.join(GEM_ROOT_DIR, "dependencies.yml"))

--- a/ext/commonmarker/_help.rb
+++ b/ext/commonmarker/_help.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+SELMA_HELP_MESSAGE = <<~HELP
+  USAGE: ruby #{$PROGRAM_NAME} [options]
+
+    Flags that are always valid:
+
+      --disable-clean
+          Do not clean out intermediate files after successful build.
+
+
+    Flags only used when using system libraries:
+
+      General:
+
+        --with-opt-dir=DIRECTORY
+            Look for headers and libraries in DIRECTORY.
+
+        --with-opt-lib=DIRECTORY
+            Look for libraries in DIRECTORY.
+
+        --with-opt-include=DIRECTORY
+            Look for headers in DIRECTORY.
+
+    Flags only used when building and using the packaged libraries:
+
+      --disable-static
+          Do not statically link packaged libraries, instead use shared libraries.
+
+      --enable-cross-build
+          Enable cross-build mode. (You probably do not want to set this manually.)
+
+      --debug
+          Take steps to prevent stripping the symbol table and debugging info from the shared
+          library, potentially overriding RbConfig's CFLAGS/LDFLAGS/DLDFLAGS.
+
+    Environment variables used:
+
+      CC
+          Use this path to invoke the compiler instead of `RbConfig::CONFIG['CC']`
+
+      CPPFLAGS
+          If this string is accepted by the C preprocessor, add it to the flags passed to the C preprocessor
+
+      CFLAGS
+          If this string is accepted by the compiler, add it to the flags passed to the compiler
+
+      LDFLAGS
+          If this string is accepted by the linker, add it to the flags passed to the linker
+
+      LIBS
+          Add this string to the flags passed to the linker
+HELP
+
+def do_help
+  print(SELMA_HELP_MESSAGE)
+  exit!(0)
+end
+
+do_help if arg_config("--help")

--- a/ext/commonmarker/_util.rb
+++ b/ext/commonmarker/_util.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+RUBY_MAJOR, RUBY_MINOR = RUBY_VERSION.split(".").collect(&:to_i)
+
+PACKAGE_ROOT_DIR = File.expand_path(File.join(File.dirname(__FILE__), "..", ".."))
+PACKAGE_EXT_DIR = File.join(PACKAGE_ROOT_DIR, "ext", "selma")
+
+REQUIRED_MINI_PORTILE_VERSION = "~> 2.8.0" # keep this version in sync with the one in the gemspec
+
+OS = case os = RbConfig::CONFIG["host_os"].downcase
+when /linux/
+  # The official ruby-alpine Docker containers pre-build Ruby. As a result,
+  #   Ruby doesn't know that it's on a musl-based platform. `ldd` is the
+  #   only reliable way to detect musl that we've found.
+  # See https://github.com/skylightio/skylight-ruby/issues/92
+  if ENV["SKYLIGHT_MUSL"] || %x(ldd --version 2>&1).include?("musl")
+    "linux-musl"
+  else
+    "linux"
+  end
+when /darwin/
+  "darwin"
+when /freebsd/
+  "freebsd"
+when /netbsd/
+  "netbsd"
+when /openbsd/
+  "openbsd"
+when /sunos|solaris/
+  "solaris"
+when /mingw|mswin/
+  "windows"
+else
+  os
+end
+
+# Normalize the platform CPU
+ARCH = case cpu = RbConfig::CONFIG["host_cpu"].downcase
+when /amd64|x86_64|x64/
+  "x86_64"
+when /i?86|x86|i86pc/
+  "x86"
+when /ppc|powerpc/
+  "powerpc"
+when /^aarch/
+  "aarch"
+when /^arm/
+  "arm"
+else
+  cpu
+end
+
+def windows?
+  OS == "windows"
+end
+
+def solaris?
+  OS == solaries
+end
+
+def darwin?
+  OS == "darwin"
+end
+
+def macos?
+  darwin? || OS == "macos"
+end
+
+def openbsd?
+  OS == "openbsd"
+end
+
+def aix?
+  OS == "aix"
+end
+
+def nix?
+  !(windows? || solaris? || darwin?)
+end
+
+def x86_64?
+  ARCH == "x86_64"
+end
+
+def x86?
+  ARCH == "x86"
+end
+
+def chdir_for_build(&block)
+  # When using rake-compiler-dock on Windows, the underlying Virtualbox shared
+  # folders don't support symlinks.
+  # Work around this limitation by using the temp dir for cooking.
+  build_dir = /mingw|mswin|cygwin/.match?(ENV["RCD_HOST_RUBY_PLATFORM"].to_s) ? "/tmp" : "."
+  Dir.chdir(build_dir, &block)
+end
+
+def abs_path(path)
+  File.join(PACKAGE_EXT_DIR, path)
+end
+
+def copy_packaged_library_headers(to_path:, from:)
+  FileUtils.mkdir_p(to_path)
+  from.each do |header_loc|
+    FileUtils.cp_r(Dir[File.join(header_loc, "*.h")], to_path)
+  end
+end
+
+def copy_packaged_binaries(bin_loc, to_path:)
+  FileUtils.mkdir_p(to_path)
+  FileUtils.cp(bin_loc, to_path)
+end
+
+def find_header_or_abort(header, *paths)
+  find_header(header, *paths) || abort("lol_html.h was expected in `#{paths.join(", ")}`, but it is missing.")
+end
+
+def find_library_or_abort(lib, func, *paths)
+  find_library(lib, func, *paths) || abort("#{lib} was expected in `#{paths.join(", ")}`, but it is missing.")
+end
+
+def concat_flags(*args)
+  args.compact.join(" ")
+end
+
+def copy_packaged_libraries_headers(from_path, to_path)
+  FileUtils.rm_rf(to_path, secure: true)
+  FileUtils.mkdir(to_path)
+  FileUtils.cp_r(Dir[File.join(from_path, "include/*")], to_path)
+end
+
+def uncertain_linux?
+  ["arm", "aarch"].include?(ARCH) && OS == "linux"
+end

--- a/ext/commonmarker/commonmarker.c
+++ b/ext/commonmarker/commonmarker.c
@@ -1,0 +1,149 @@
+#include "ruby.h"
+
+#include "commonmarker.h"
+
+#include "comrak_ffi.h"
+
+int iterate_extension_options(VALUE key, VALUE val, VALUE arg) {
+  comrak_options_t *config = (comrak_options_t *)arg;
+
+  if (key == ID2SYM(rb_intern("strikethrough"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_extension_option_strikethrough(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("tagfilter"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_extension_option_tagfilter(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("table"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_extension_option_table(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("autolink"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_extension_option_autolink(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("tasklist"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_extension_option_tasklist(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("superscript"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_extension_option_superscript(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("header_ids"))) {
+    Check_Type(val, T_STRING);
+    comrak_set_extension_option_header_ids(config, StringValuePtr(val),
+                                           RSTRING_LEN(val));
+  } else if (key == ID2SYM(rb_intern("footnotes"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_extension_option_footnotes(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("description_lists"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_extension_option_description_lists(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("front_matter_delimiter"))) {
+    Check_Type(val, T_STRING);
+    comrak_set_extension_option_front_matter_delimiter(
+        config, StringValuePtr(val), RSTRING_LEN(val));
+  }
+
+  return ST_CONTINUE;
+}
+
+int iterate_render_options(VALUE key, VALUE val, VALUE arg) {
+  comrak_options_t *config = (comrak_options_t *)arg;
+
+  if (key == ID2SYM(rb_intern("hardbreaks"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_render_option_hardbreaks(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("github_pre_lang"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_render_option_github_pre_lang(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("width"))) {
+    Check_Type(val, T_FIXNUM);
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_render_option_github_pre_lang(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("unsafe_"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_render_option_unsafe_(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("escape"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_render_option_escape(config, val);
+    }
+  }
+
+  return ST_CONTINUE;
+}
+
+int iterate_parse_options(VALUE key, VALUE val, VALUE arg) {
+  comrak_options_t *config = (comrak_options_t *)arg;
+
+  if (key == ID2SYM(rb_intern("smart"))) {
+    if (TYPE(val) == T_TRUE || TYPE(val) == T_FALSE) {
+      comrak_set_parse_option_smart(config, val);
+    }
+  } else if (key == ID2SYM(rb_intern("default_info_string"))) {
+    Check_Type(val, T_STRING);
+
+    comrak_set_parse_option_default_info_string(config, StringValuePtr(val),
+                                                RSTRING_LEN(val));
+  }
+
+  return ST_CONTINUE;
+}
+
+int iterate_options_hash(VALUE rb_option_key, VALUE rb_option_val, VALUE arg) {
+  comrak_options_t *config = (comrak_options_t *)arg;
+
+  Check_Type(rb_option_key, T_SYMBOL);
+
+  // which options are we dealing with?
+  if (rb_option_key == ID2SYM(rb_intern("parse"))) {
+    Check_Type(rb_option_val, T_HASH);
+    rb_hash_foreach(rb_option_val, iterate_parse_options, (VALUE)config);
+  } else if (rb_option_key == ID2SYM(rb_intern("render"))) {
+    Check_Type(rb_option_val, T_HASH);
+    rb_hash_foreach(rb_option_val, iterate_render_options, (VALUE)config);
+  } else if (rb_option_key == ID2SYM(rb_intern("extension"))) {
+    Check_Type(rb_option_val, T_HASH);
+    if (rb_hash_aref(rb_option_val, ID2SYM(rb_intern("header_ids"))) == Qnil) {
+      comrak_set_extension_option_header_ids(config, NULL, 0);
+    }
+    rb_hash_foreach(rb_option_val, iterate_extension_options, (VALUE)config);
+  }
+
+  return ST_CONTINUE;
+}
+
+VALUE commonmark_to_html(VALUE self, VALUE rb_commonmark, VALUE rb_options) {
+  Check_Type(rb_commonmark, T_STRING);
+  Check_Type(rb_options, T_HASH);
+
+  char *commonmark = StringValueCStr(rb_commonmark);
+
+  comrak_options_t *options = comrak_options_new();
+  rb_hash_foreach(rb_options, iterate_options_hash, (VALUE)options);
+
+  comrak_str_t html = comrak_commonmark_to_html(commonmark, options);
+
+  VALUE rb_html = rb_utf8_str_new(html.data, html.len);
+
+  comrak_options_free(options);
+  comrak_str_free(html);
+
+  return rb_html;
+}
+
+__attribute__((visibility("default"))) void Init_commonmarker() {
+  VALUE module;
+
+  module = rb_define_module("Commonmarker");
+  rb_define_singleton_method(module, "commonmark_to_html", commonmark_to_html,
+                             2);
+}

--- a/ext/commonmarker/commonmarker.h
+++ b/ext/commonmarker/commonmarker.h
@@ -1,0 +1,18 @@
+#ifndef COMMONMARKER_H
+#define COMMONMARKER_H
+
+#ifndef __MSXML_LIBRARY_DEFINED__
+#define __MSXML_LIBRARY_DEFINED__
+#endif
+
+#include "ruby.h"
+#include "ruby/encoding.h"
+
+#include "comrak_ffi.h"
+
+#define CSTR2SYM(s) (ID2SYM(rb_intern((s))))
+
+void Init_commonmarker();
+VALUE commonmark_to_html(VALUE self, VALUE rb_commonmark, VALUE rb_options);
+
+#endif

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -1,0 +1,96 @@
+require "mkmf"
+
+require_relative "_util"
+require_relative "_config"
+require_relative "_help"
+
+GEM_ROOT_DIR = File.expand_path(File.join(File.dirname(__FILE__), "..", ".."))
+
+if debug?
+  puts "Compiling in debug mode (using Ruby #{RUBY_VERSION})..."
+
+  require "debug"
+  require "awesome_print"
+
+  append_cflags("-Wextra")
+  append_cflags("-fno-omit-frame-pointer")
+  append_cflags("-fno-optimize-sibling-calls")
+  CONFIG["debugflags"] = "-ggdb -g"
+  CONFIG["optflags"] = "-O0"
+end
+
+static_linking = config_static?
+puts "Static linking is #{static_linking ? "enabled" : "disabled"}."
+
+cross_build_p = config_cross_build?
+puts "Cross build is #{cross_build_p ? "enabled" : "disabled"}."
+
+require_relative "_cflags"
+
+RbConfig::CONFIG["CC"] = RbConfig::MAKEFILE_CONFIG["CC"] = ENV.fetch("CC", nil) if ENV["CC"]
+
+# use same c compiler
+ENV["CC"] = RbConfig::CONFIG["CC"]
+
+require_relative "_comrak"
+COMRAK_RECIPE = build_comrak
+
+lib_header_path = File.join(COMRAK_RECIPE.path, "include")
+lib_build_path = File.join(COMRAK_RECIPE.path, "release")
+
+HEADER_DIRS = [lib_header_path]
+LIB_DIRS = [lib_build_path]
+
+if uncertain_linux?
+  # FIXME: does not appear to work
+elsif config_static?
+  $LIBS << ' -l:libcomrak_ffi.a'
+else
+  $LIBS << ' -lcomrak_ffi'
+end
+
+if !windows?
+  if config_static?
+    $libs << " #{File.join(lib_build_path, "libcomrak_ffi.#{$LIBEXT}")}"
+  end
+
+  $LDFLAGS += " -L#{lib_build_path}/libcomrak_ffi.a"
+
+  $LIBPATH = ["#{COMRAK_RECIPE.path}/release"] | $LIBPATH
+  pkg_config('comrak_ffi')
+
+else
+  append_cppflags("-I#{lib_header_path}")
+
+  if config_static?
+    $libs << ' -lcomrak_ffi'
+    $LDFLAGS += " -L#{lib_build_path}"
+  end
+
+  $LIBPATH = [lib_build_path] | $LIBPATH
+  pkg_config('comrak_ffi')
+end
+
+
+# xref: https://github.com/sparklemotion/nokogiri/blob/fe9cc9893463a660477e25820b53f19518c286b7/ext/nokogiri/extconf.rb#L982
+if config_cross_build?
+  # When precompiling native gems, copy packaged libraries' headers to ext/commonmarker/include
+  # These are packaged up by the cross-compiling callback in the ExtensionTask
+  copy_packaged_libraries_headers(COMRAK_RECIPE.path, File.join(GEM_ROOT_DIR, "ext/commonmarker/include"))
+else
+  # When compiling during installation, install packaged libraries' header files into ext/commonmarker/include
+  copy_packaged_libraries_headers(COMRAK_RECIPE.extracted_ffi_path, File.join(GEM_ROOT_DIR, "ext/commonmarker/include"))
+  $INSTALLFILES << ["ext/commonmarker/include/**/*.h", "$(rubylibdir)"]
+end
+
+dir_config('commonmarker', HEADER_DIRS, LIB_DIRS)
+
+if uncertain_linux?
+  # FIXME: does not appear to work
+else
+  unless find_header("comrak_ffi.h", HEADER_DIRS)
+    abort("\nERROR: *** could not find comrak_ffi.h ***\n\n")
+  end
+end
+
+create_makefile("commonmarker/commonmarker")

--- a/lib/commonmarker.rb
+++ b/lib/commonmarker.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative "commonmarker/extension"
+
+require "commonmarker/config"
+require "commonmarker/renderer"
+require "commonmarker/version"
+
+if ENV.fetch("DEBUG", false)
+  require "awesome_print"
+  require "debug"
+end
+
+module Commonmarker
+  class << self
+    # Public: Parses a CommonMark string into an HTML string.
+    #
+    # text - A {String} of text
+    # option - A {Hash} of render, parse, and extension options to transform the text.
+    #
+    # Returns a {String} of converted HTML.
+    def to_html(text, options: Commonmarker::Config::OPTS)
+      raise TypeError, "text must be a String; got a #{text.class}!" unless text.is_a?(String)
+      raise TypeError, "options must be a Hash; got a #{options.class}!" unless options.is_a?(Hash)
+
+      opts = Config.process_options(options)
+      commonmark_to_html(text.encode("UTF-8"), opts)
+    end
+  end
+end

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Commonmarker
+  module Config
+    # For details, see
+    # https://github.com/kivikakk/comrak/blob/162ef9354deb2c9b4a4e05be495aa372ba5bb696/src/main.rs#L201
+    OPTS = {
+      parse: {
+        smart: false,
+        default_info_string: "",
+      }.freeze,
+      render: {
+        hardbreaks: true,
+        github_pre_lang: true,
+        width: 80,
+        unsafe_: false,
+        escape: false,
+      }.freeze,
+      extension: {
+        strikethrough: true,
+        tagfilter: true,
+        table: true,
+        autolink: true,
+        tasklist: true,
+        superscript: false,
+        header_ids: "",
+        footnotes: false,
+        description_lists: false,
+        front_matter_delimiter: "",
+      },
+      format: [:html].freeze,
+    }.freeze
+
+    class << self
+      def merged_with_defaults(options)
+        Commonmarker::Config::OPTS.merge(process_options(options))
+      end
+
+      def process_options(options)
+        {
+          parse: process_parse_options(options[:parse]),
+          render: process_render_options(options[:render]),
+          extension: process_extension_options(options[:extension]),
+        }
+      end
+    end
+
+    BOOLS = [true, false]
+    ["parse", "render", "extension"].each do |type|
+      define_singleton_method :"process_#{type}_options" do |options|
+        Commonmarker::Config::OPTS[type.to_sym].each_with_object({}) do |(key, value), hash|
+          if options.nil? # option not provided, go for the default
+            hash[key] = value
+            next
+          end
+
+          # option explicitly not included, remove it
+          next if options[key].nil?
+
+          value_klass = value.class
+          if BOOLS.include?(value) && BOOLS.include?(options[key])
+            hash[key] = options[key]
+          elsif options[key].is_a?(value_klass)
+            hash[key] = options[key]
+          else
+            expected_type = BOOLS.include?(value) ? "Boolean" : value_klass.to_s
+            raise TypeError, "#{type}_options[:#{key}] must be a #{expected_type}; got #{options[key].class}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/commonmarker/extension.rb
+++ b/lib/commonmarker/extension.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+begin
+  # native precompiled gems package shared libraries in <gem_dir>/lib/commonmarker/<ruby_version>
+  # load the precompiled extension file
+  ruby_version = /\d+\.\d+/.match(::RUBY_VERSION)
+  require_relative "#{ruby_version}/commonmarker"
+rescue LoadError
+  # fall back to the extension compiled upon installation.
+  # use "require" instead of "require_relative" because non-native gems will place C extension files
+  # in Gem::BasicSpecification#extension_dir after compilation (during normal installation), which
+  # is in $LOAD_PATH but not necessarily relative to this file (see nokogiri#2300)
+  require "commonmarker/commonmarker"
+end

--- a/lib/commonmarker/renderer.rb
+++ b/lib/commonmarker/renderer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "set"
+require "stringio"
+
+module Commonmarker
+  class Renderer
+  end
+end

--- a/lib/commonmarker/version.rb
+++ b/lib/commonmarker/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Commonmarker
+  VERSION = "1.0.0.pre"
+end

--- a/rakelib/benchmark.rake
+++ b/rakelib/benchmark.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+desc "Run benchmarks"
+task :benchmark do
+  unless File.exist?("test/progit")
+    %x(rm -rf test/progit)
+    %x(git clone https://github.com/progit/progit.git test/progit)
+    langs = ["ar", "az", "be", "ca", "cs", "de", "en", "eo", "es", "es-ni", "fa", "fi", "fr", "hi", "hu", "id", "it", "ja", "ko", "mk", "nl", "no-nb", "pl", "pt-br", "ro", "ru", "sr", "th", "tr", "uk", "vi", "zh", "zh-tw"]
+    langs.each do |lang|
+      %x(cat test/progit/#{lang}/*/*.markdown >> test/benchinput.md)
+    end
+  end
+  $LOAD_PATH.unshift("lib")
+  load "test/benchmark.rb"
+end

--- a/rakelib/clean.rake
+++ b/rakelib/clean.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rake/clean"
+CLEAN.add(
+  "coverage",
+  "ext/commonmarker/include",
+  "lib/commonmarker/[0-9].[0-9]",
+  "lib/commonmarker/commonmarker.{bundle,jar,rb,so}",
+  "pkg",
+  "tmp",
+)
+CLEAN.add("ports/*").exclude(%r{ports/archives$})

--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "date"
+require "rdoc/task"
+
+namespace :docs do
+  desc "Generate API documentation"
+  RDoc::Task.new do |rd|
+    rd.rdoc_dir = "docs"
+    rd.main     = "README.md"
+    rd.rdoc_files.include("README.md", "lib/**/*.rb", "ext/commonmarker/commonmarker.c")
+
+    rd.options << "--markup tomdoc"
+    rd.options << "--inline-source"
+    rd.options << "--line-numbers"
+    rd.options << "--all"
+    rd.options << "--fileboxes"
+  end
+
+  desc "Generate the documentation and run a web server"
+  task serve: [:rdoc] do
+    require "webrick"
+
+    puts "Navigate to http://localhost:3000 to see the docs"
+
+    server = WEBrick::HTTPServer.new(Port: 3000)
+    server.mount("/", WEBrick::HTTPServlet::FileHandler, "docs")
+    trap("INT") { server.stop }
+    server.start
+  end
+
+  desc "Generate and publish docs to gh-pages"
+  task publish: [:rdoc] do
+    require "tmpdir"
+    require "shellwords"
+
+    Dir.mktmpdir do |tmp|
+      system "mv docs/* #{tmp}"
+      system "git checkout origin/gh-pages"
+      system "rm -rf *"
+      system "mv #{tmp}/* ."
+      message = Shellwords.escape("Site updated at #{Time.now.utc}")
+      system "git add ."
+      system "git commit -am #{message}"
+      system "git push origin gh-pages --force"
+      system "git checkout master"
+      system "echo yolo"
+    end
+  end
+end

--- a/rakelib/extensions.rake
+++ b/rakelib/extensions.rake
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+require "rake_compiler_dock"
+
+require "rake_compiler_dock"
+
+require_relative "extensions/util"
+require_relative "extensions/cross_rubies"
+
+ENV["RUBY_CC_VERSION"] = CROSS_RUBIES.map(&:ver).uniq.join(":")
+
+def install_additional_packages_for(cr)
+  if cr.darwin?
+    [
+      "curl https://sh.rustup.rs -sSf > rustup.sh",
+      "bash rustup.sh -y; PATH=\"$HOME/.cargo/bin:${PATH}\"",
+      "cargo --version",
+    ].join(" && ")
+  elsif cr.linux?
+    [
+      "sudo apt-get update -y",
+      "sudo apt-get install -y cargo",
+    ].join(" && ")
+  end
+end
+
+namespace "gem" do
+  CROSS_RUBIES.find_all { |cr| cr.windows? || cr.linux? || cr.darwin? }.map(&:platform).uniq.each do |platform|
+    cr = CROSS_RUBIES.find { |cr| cr.platform == platform }
+
+    desc "build native gem for #{platform} platform"
+    task platform do
+      puts "Invoking RakeCompilerDock for #{platform} ..."
+      RakeCompilerDock.sh(<<~EOT, platform: platform, verbose: true)
+        #{install_additional_packages_for(cr)}
+        rvm use 3.1.0 &&
+        gem install bundler --no-document &&
+        bundle &&
+        bundle exec rake gem:#{platform}:builder MAKE='nice make -j`nproc`'
+      EOT
+    end
+
+    namespace platform do
+      desc "build native gem for #{platform} platform (guest container)"
+      task "builder" do
+        puts "Invoking native:#{platform} ..."
+        # use Task#invoke because the pkg/*gem task is defined at runtime
+        Rake::Task["native:#{platform}"].invoke
+        puts "Invoking #{"pkg/#{COMMONMARKER_SPEC.full_name}-#{Gem::Platform.new(platform)}.gem"}  ..."
+
+        Rake::Task["pkg/#{COMMONMARKER_SPEC.full_name}-#{Gem::Platform.new(platform)}.gem"].invoke
+      end
+    end
+  end
+
+  desc "build native gems for windows"
+  multitask "windows" => CROSS_RUBIES.find_all(&:windows?).map(&:platform).uniq
+
+  desc "build native gems for linux"
+  multitask "linux" => CROSS_RUBIES.find_all(&:linux?).map(&:platform).uniq
+
+  desc "build native gems for darwin"
+  multitask "darwin" => CROSS_RUBIES.find_all(&:darwin?).map(&:platform).uniq
+end
+
+require "rake/extensiontask"
+
+# FIXME: remove this hack if multiple versions of Ruby are supported...
+module Rake
+  class ExtensionTask < BaseExtensionTask
+    def define_cross_platform_tasks(for_platform)
+      ruby_vers = ENV["RUBY_CC_VERSION"].split(":")
+
+      old_multi = ruby_vers.size > 1 ? true : false
+      multi = true
+      puts "DEBUG: multi = #{multi} (was: #{old_multi})"
+      ruby_vers.each do |version|
+        # save original lib_dir
+        orig_lib_dir = @lib_dir
+
+        # tweak lib directory only when targeting multiple versions
+        if multi
+          version =~ /(\d+\.\d+)/
+          @lib_dir = "#{@lib_dir}/#{::Regexp.last_match(1)}"
+        end
+
+        define_cross_platform_tasks_with_version(for_platform, version)
+
+        # restore lib_dir
+        @lib_dir = orig_lib_dir
+      end
+    end
+  end
+end
+
+require_relative "extensions/dependencies"
+
+Rake::ExtensionTask.new("commonmarker", COMMONMARKER_SPEC.dup) do |ext|
+  ext.source_pattern = "*.{c,h}"
+
+  lib_dir = File.join(*["lib", "commonmarker", ENV["FAT_DIR"]].compact)
+  ext.lib_dir = lib_dir
+  ext.config_options << ENV["EXTOPTS"]
+  ext.cross_compile = true
+  ext.cross_platform = CROSS_RUBIES.map(&:platform).uniq
+  ext.cross_config_options << "--enable-cross-build" # so extconf.rb knows we're cross-compiling
+  ext.cross_compiling do |spec|
+    # remove things not needed for precompiled gems
+    spec.files.reject! { |path| File.fnmatch?("ports/*", path) }
+    spec.files.reject! { |file| File.fnmatch?("*.tar.gz", file) }
+    spec.files.reject! { |file| File.fnmatch?("*.bundle", file) }
+    spec.dependencies.reject! { |dep| dep.name == "mini_portile2" }
+
+    # when pre-compiling a native gem, package all the C headers sitting in ext/commonmarker/include
+    # which were copied there in the $INSTALLFILES section of extconf.rb.
+    # (see script/test-gem-file-contents and script/test-gem-installation for tests)
+    headers_dir = "ext/commonmarker/include"
+
+    Dir.glob(File.join(headers_dir, "**", "*.h")).each do |header|
+      spec.files << header
+    end
+
+    # FIXME: remove this hack if multiple versions of Ruby are supported...
+    is_darwin = spec.platform.os == "darwin"
+    extension = is_darwin ? "bundle" : "so"
+    spec.files << "lib/commonmarker/3.1/commonmarker.#{extension}"
+  end
+end

--- a/rakelib/extensions/cross_rubies.rb
+++ b/rakelib/extensions/cross_rubies.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+CrossRuby = Struct.new(:version, :platform) do
+  WINDOWS_PLATFORM_REGEX = /mingw|mswin/
+  MINGWUCRT_PLATFORM_REGEX = /mingw-ucrt/
+  MINGW32_PLATFORM_REGEX = /mingw32/
+  LINUX_PLATFORM_REGEX = /linux/
+  X86_LINUX_PLATFORM_REGEX = /x86.*linux/
+  AARCH_LINUX_PLATFORM_REGEX = /aarch.*linux/
+  ARM_LINUX_PLATFORM_REGEX = /arm-linux/
+  DARWIN_PLATFORM_REGEX = /darwin/
+
+  def windows?
+    !!(platform =~ WINDOWS_PLATFORM_REGEX)
+  end
+
+  def linux?
+    !!(platform =~ LINUX_PLATFORM_REGEX)
+  end
+
+  def darwin?
+    !!(platform =~ DARWIN_PLATFORM_REGEX)
+  end
+
+  def ver
+    @ver ||= version[/\A[^-]+/]
+  end
+
+  def minor_ver
+    @minor_ver ||= ver[/\A\d\.\d(?=\.)/]
+  end
+
+  def api_ver_suffix
+    case minor_ver
+    when nil
+      raise "CrossRuby.api_ver_suffix: unsupported version: #{ver}"
+    else
+      minor_ver.delete(".") << "0"
+    end
+  end
+
+  def host
+    @host ||= case platform
+    when "x64-mingw-ucrt"
+      "x86_64-w64-mingw32"
+    when "x64-mingw32"
+      "x86_64-w64-mingw32"
+    when "x86-mingw32"
+      "i686-w64-mingw32"
+    when "x86_64-linux"
+      "x86_64-linux-gnu"
+    when "x86-linux"
+      "i686-linux-gnu"
+    when "aarch64-linux"
+      "aarch64-linux"
+    when "x86_64-darwin"
+      "x86_64-darwin"
+    when "arm64-darwin"
+      "aarch64-darwin"
+    else
+      raise "CrossRuby.platform: unsupported platform: #{platform}"
+    end
+  end
+
+  def tool(name)
+    (@binutils_prefix ||= case platform
+     when "x64-mingw-ucrt", "x64-mingw32"
+       "x86_64-w64-mingw32-"
+     when "x86-mingw32"
+       "i686-w64-mingw32-"
+     when "x86_64-linux"
+       "x86_64-redhat-linux-"
+     when "x86-linux"
+       "i686-redhat-linux-"
+     when "aarch64-linux"
+       "aarch64-linux-gnu-"
+     when "x86_64-darwin"
+       "x86_64-apple-darwin-"
+     when "arm64-darwin"
+       "aarch64-apple-darwin-"
+     when "arm-linux"
+       "arm-linux-gnueabihf-"
+     else
+       raise "CrossRuby.tool: unmatched platform: #{platform}"
+     end) + name
+  end
+
+  def target_file_format
+    case platform
+    when "x64-mingw-ucrt", "x64-mingw32"
+      "pei-x86-64"
+    when "x86-mingw32"
+      "pei-i386"
+    when "x86_64-linux"
+      "elf64-x86-64"
+    when "x86-linux"
+      "elf32-i386"
+    when "aarch64-linux"
+      "elf64-littleaarch64"
+    when "x86_64-darwin"
+      "Mach-O 64-bit x86-64" # hmm
+    when "arm64-darwin"
+      "Mach-O arm64"
+    when "arm-linux"
+      "elf32-littlearm"
+    else
+      raise "CrossRuby.target_file_format: unmatched platform: #{platform}"
+    end
+  end
+
+  def libruby_dll
+    case platform
+    when "x64-mingw-ucrt"
+      "x64-ucrt-ruby#{api_ver_suffix}.dll"
+    when "x64-mingw32"
+      "x64-msvcrt-ruby#{api_ver_suffix}.dll"
+    when "x86-mingw32"
+      "msvcrt-ruby#{api_ver_suffix}.dll"
+    else
+      raise "CrossRuby.libruby_dll: unmatched platform: #{platform}"
+    end
+  end
+end
+
+CROSS_RUBIES = File.read(".cross_rubies").split("\n").filter_map do |line|
+  case line
+  when /\A([^#]+):([^#]+)/
+    CrossRuby.new(Regexp.last_match(1), Regexp.last_match(2))
+  end
+end

--- a/rakelib/extensions/dependencies.rb
+++ b/rakelib/extensions/dependencies.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "yaml"
+dependencies = YAML.load_file("dependencies.yml")
+
+task gem_build_path do
+  ["comrak"].each do |name|
+    version = dependencies[name]["version"]
+
+    archive = Dir.glob(File.join("ports", "archives", "#{name}-#{version}.tar.*")).first
+    add_file_to_gem(archive)
+  end
+end

--- a/rakelib/extensions/util.rb
+++ b/rakelib/extensions/util.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+def gem_build_path
+  File.join("pkg", COMMONMARKER_SPEC.full_name)
+end
+
+def add_file_to_gem(relative_source_path)
+  if relative_source_path.nil? || !File.exist?(relative_source_path)
+    raise "Cannot find file '#{relative_source_path}'"
+  end
+
+  dest_path = File.join(gem_build_path, relative_source_path)
+  dest_dir = File.dirname(dest_path)
+
+  puts "Adding #{relative_source_path} to gem"
+
+  mkdir_p(dest_dir) unless Dir.exist?(dest_dir)
+  rm_f(dest_path) if File.exist?(dest_path)
+  safe_ln(relative_source_path, dest_path)
+
+  COMMONMARKER_SPEC.files << relative_source_path
+end

--- a/rakelib/format.rake
+++ b/rakelib/format.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+begin
+  require "rubocop/rake_task"
+
+  RuboCop::RakeTask.new(:rubocop)
+
+  desc("Match C style of cmark")
+  task(:format) do
+    sh("clang-format -style llvm -i ext/commonmarker/*.c ext/commonmarker/*.h")
+  end
+rescue LoadError => e
+  warn("WARNING: rubocop is not available in this environment: #{e}")
+end

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require "rubygems/package_task"
+Gem::PackageTask.new(COMMONMARKER_SPEC).define

--- a/rakelib/set-version-to-timestamp.rake
+++ b/rakelib/set-version-to-timestamp.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+desc "Temporarily set Commonmarker::VERSION to a unique timestamp"
+task "set-version-to-timestamp" do
+  # this task is used by script/test-gem-build
+  # to test building, packaging, and installing a Commonmarker gem
+  version_constant_re = /^\s*VERSION\s*=\s*["'](.*)["']$/
+
+  version_file_path = File.join(File.dirname(__FILE__), "..", "lib/commonmarker/version.rb")
+  version_file_contents = File.read(version_file_path)
+
+  current_version_string = version_constant_re.match(version_file_contents)[1]
+  current_version = Gem::Version.new(current_version_string)
+
+  fake_version = Gem::Version.new(format("%s.test.%s", current_version.bump, Time.now.strftime("%Y.%m%d.%H%M")))
+
+  unless version_file_contents.gsub!(version_constant_re, "  VERSION = \"#{fake_version}\"")
+    raise("Could not hack the VERSION constant")
+  end
+
+  File.write(version_file_path, version_file_contents)
+
+  puts "NOTE: wrote version as \"#{fake_version}\""
+end

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+Rake::TestTask.new("test:unit") do |t|
+  t.libs << "lib"
+  t.libs << "test"
+  t.pattern = "test/test_*.rb"
+  t.verbose = true
+  t.warning = false
+end
+
+desc "Run unit tests"
+task "test:unit" => :compile
+
+desc "Run unit and conformance tests"
+task test: ["test:unit"]

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+echo "==> Installing gem dependencies…"
+
+bundle install

--- a/script/build-gems
+++ b/script/build-gems
@@ -1,0 +1,47 @@
+#! /usr/bin/env bash
+#
+#  script to build gems for all relevant platforms
+#
+set -o errexit
+set -o nounset
+set -x
+
+rm -rf tmp pkg gems
+mkdir -p gems
+
+# prelude: let's check that things work
+bundle update
+bundle package
+
+bundle exec rake clean clobber
+bundle exec rake compile
+bundle exec rake test
+bundle exec rake test:bench
+
+# MRI et al (standard gem)
+bundle exec rake clean clobber
+bundle exec rake gem
+cp -v pkg/commonmarker*.gem gems
+
+# precompiled native gems ("fat binary")
+bundle update
+bundle package
+
+bundle exec rake clean clobber
+bundle exec rake gem:windows
+cp -v pkg/commonmarker-*mingw*.gem gems
+
+bundle exec rake clean clobber
+bundle exec rake gem:linux
+cp -v pkg/commonmarker-*linux*.gem gems
+
+bundle exec rake clean clobber
+bundle exec rake gem:darwin
+cp -v pkg/commonmarker-*darwin*.gem gems
+
+# test those gem files!
+$(dirname $0)/test-gem-set gems/*.gem
+
+pushd gems
+  ls *.gem | sort | xargs sha256sum
+popd

--- a/script/changelog
+++ b/script/changelog
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+CHANGELOG_GITHUB_TOKEN="$PUBLIC_GITHUB_TOKEN" github_changelog_generator -u gjtorikian -p commonmarker

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+bundle
+bundle exec rake clean compile test

--- a/script/fetch_shasum256
+++ b/script/fetch_shasum256
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+t=$(mktemp)
+wget "$1" -qO "$t"
+shasum -a 256 "$t" | grep -Eo '^\w+'
+rm "$t"

--- a/script/single_test
+++ b/script/single_test
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+bundle exec rake compile
+bundle exec rake test TEST=test/$1

--- a/script/test-gem-build
+++ b/script/test-gem-build
@@ -1,0 +1,52 @@
+#! /usr/bin/env bash
+#
+#  run as part of CI, see gem-install.yml
+#
+if [[ $# -lt 2 ]] ; then
+  echo "usage: $(basename $0) <output_dir> <platform>"
+  exit 1
+fi
+
+set -e
+
+OUTPUT_DIR=$1
+BUILD_NATIVE_GEM=$2
+
+test -e /etc/os-release && cat /etc/os-release
+
+echo "Building ${BUILD_NATIVE_GEM} gem"
+
+set -u -x
+
+./script/test-has-rust
+
+. $HOME/.cargo/env
+
+ruby --version
+bundler -v
+rustc -Vv
+
+export BUNDLE_WITHOUT=lint:benchmark:debug:test
+bundle
+
+bundle exec rake set-version-to-timestamp
+
+if [[ "${BUILD_NATIVE_GEM}" == "ruby" ]] ; then
+  echo "Building ruby gem..."
+  bundle exec rake clean compile
+  bundle exec rake gem
+else
+  if [[ $BUILD_NATIVE_GEM == *"mingw"* ]]; then
+    echo "Downloading Rust tooling for Windows..."
+    rustup target add x86_64-pc-windows-gnu
+    rustup target add i686-pc-windows-msvc
+  fi
+  echo "Building native gem..."
+  bundle exec rake gem:${BUILD_NATIVE_GEM}:builder
+fi
+
+./script/test-gem-file-contents pkg/commonmarker*.gem
+
+mkdir -p ${OUTPUT_DIR}
+cp -v pkg/commonmarker*.gem ${OUTPUT_DIR}
+ls -l ${OUTPUT_DIR}/*

--- a/script/test-gem-file-contents
+++ b/script/test-gem-file-contents
@@ -1,0 +1,197 @@
+#! /usr/bin/env ruby
+# frozen_string_literal: true
+
+#
+#  this script is intended to run as part of the CI test suite.
+#
+#  it inspects the contents of a commonmarker gem file -- both the files and the gemspec -- to ensure
+#  we're packaging what we expect, and that we're not packaging anything we don't expect.
+#
+#  this file isn't in the `test/` subdirectory because it's intended to be run standalone against a
+#  built gem file (and not against the source code or behavior of the gem itself).
+#
+
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "minitest"
+  gem "minitest-reporters"
+end
+
+require "yaml"
+
+def usage_and_exit(message = nil)
+  puts "ERROR: #{message}" if message
+  puts "USAGE: #{File.basename(__FILE__)} <gemfile> [options]"
+  exit(1)
+end
+
+usage_and_exit if ARGV.include?("-h")
+usage_and_exit unless (gemfile = ARGV[0])
+usage_and_exit("#{gemfile} does not exist") unless File.file?(gemfile)
+usage_and_exit("#{gemfile} is not a gem") unless /\.gem$/.match?(gemfile)
+gemfile = File.expand_path(gemfile)
+
+gemfile_contents = Dir.mktmpdir do |dir|
+  Dir.chdir(dir) do
+    unless system("tar -xf #{gemfile} data.tar.gz")
+      raise "could not unpack gem #{gemfile}"
+    end
+
+    %x(tar -ztf data.tar.gz).split("\n")
+  end
+end
+
+gemspec = Dir.mktmpdir do |dir|
+  Dir.chdir(dir) do
+    unless system("tar -xf #{gemfile} metadata.gz")
+      raise "could not unpack gem #{gemfile}"
+    end
+
+    YAML.safe_load(
+      %x(gunzip -c metadata.gz),
+      permitted_classes: [Gem::Specification, Gem::Version, Gem::Dependency, Gem::Requirement, Time, Symbol],
+    )
+  end
+end
+
+if ARGV.include?("-v")
+  puts "---------- gemfile contents ----------"
+  puts gemfile_contents
+  puts
+  puts "---------- gemspec ----------"
+  puts gemspec.to_ruby
+  puts
+end
+
+require "minitest/autorun"
+require "minitest/reporters"
+Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
+
+puts "Testing '#{gemfile}' (#{gemspec.platform})"
+describe File.basename(gemfile) do
+  let(:cross_rubies_path) { File.join(File.dirname(__FILE__), "..", ".cross_rubies") }
+
+  let(:platform_supported_ruby_versions) do
+    File.read(cross_rubies_path).split("\n").filter_map do |line|
+      ver, plat = line.split(":")
+      next if plat != gemspec.platform.to_s
+
+      ver.split(".").take(2).join(".") # ugh
+    end.uniq.sort
+  end
+
+  let(:all_supported_ruby_versions) do
+    File.read(cross_rubies_path).split("\n").map do |line|
+      ver, _ = line.split(":")
+      ver.split(".").take(2).join(".") # ugh
+    end.uniq.sort
+  end
+
+  describe "setup" do
+    it "gemfile contains some files" do
+      actual = gemfile_contents.length
+      assert_operator(actual, :>, 8, "expected gemfile to contain more than #{actual} files")
+    end
+
+    it "gemspec is a Gem::Specification" do
+      assert_equal(Gem::Specification, gemspec.class)
+    end
+  end
+
+  describe "all platforms" do
+    it "contains every ruby file in lib/" do
+      expected = %x(git ls-files lib).split("\n").grep(/\.rb$/).sort
+      skip "looks like this isn't a git repository" if expected.empty?
+      actual = gemfile_contents.grep(%r{^lib/}).grep(/\.rb$/).sort
+      assert_equal(expected, actual)
+    end
+  end
+
+  describe "ruby platform" do
+    it "depends on mini_portile2" do
+      assert(gemspec.dependencies.find { |d| d.name == "mini_portile2" })
+    end
+
+    it "contains ext/commonmarker C and header files" do
+      assert_equal(gemfile_contents.grep(%r{^ext/commonmarker/.*\.c}).length, 1)
+      assert_equal(gemfile_contents.grep(%r{^ext/commonmarker/.*\.h}).length, 1)
+    end
+
+    it "contains the port files" do
+      actual_ports = gemfile_contents.grep(%r{^ports/})
+      assert_equal(1, actual_ports.grep(/comrak-(?:\d+\.\d+\.\d+|[a-z0-9]{40}).tar\.[gx]z/).length,
+        "expected #{actual_ports} to include comrak")
+      assert_equal(1, actual_ports.length)
+    end
+
+    it "does not contain packaged libraries' header files" do
+      # these files are present after installation if the packaged libraries are used
+      assert_empty(gemfile_contents.grep(%r{^ext/commonmarker/include/}))
+    end
+  end if gemspec.platform == Gem::Platform::RUBY
+
+  describe "native platform" do
+    it "does not depend on mini_portile2" do
+      refute(gemspec.dependencies.find { |d| d.name == "mini_portile2" })
+    end
+
+    it "contains ext/commonmarker C and header files" do
+      assert_equal(gemfile_contents.grep(%r{^ext/commonmarker/.*\.c}).length, 1)
+      # second is comrak_ffi.h
+      assert_equal(gemfile_contents.grep(%r{^ext/commonmarker/.*\.h}).length, 2)
+    end
+
+    it "does not contain the port files" do
+      assert_empty(gemfile_contents.grep(%r{^ports/}))
+    end
+
+    it "does not contain the patch files" do
+      assert_empty(gemfile_contents.grep(%r{^patches/}))
+    end
+
+    it "contains packaged libraries' header files" do
+      assert_includes(gemfile_contents, "ext/commonmarker/include/comrak_ffi.h")
+    end
+
+    it "contains expected shared library files" do
+      platform_supported_ruby_versions.each do |version|
+        actual = gemfile_contents.find do |file|
+          File.fnmatch?("lib/commonmarker/#{version}/commonmarker.{so,bundle}", file, File::FNM_EXTGLOB)
+        end
+        assert(actual, "expected to find shared library file for ruby #{version}")
+      end
+
+      actual = gemfile_contents.find do |file|
+        File.fnmatch?("lib/commonmarker/commonmarker.{so,bundle}", file, File::FNM_EXTGLOB)
+      end
+      refute(actual, "did not expect to find shared library file in lib/commonmarker")
+
+      actual = gemfile_contents.find_all do |file|
+        File.fnmatch?("lib/commonmarker/**/*.{so,bundle}", file, File::FNM_EXTGLOB)
+      end
+      assert_equal(
+        platform_supported_ruby_versions.length,
+        actual.length,
+        "did not expect extra shared library files",
+      )
+    end
+
+    it "sets required_ruby_version appropriately" do
+      unsupported_versions = all_supported_ruby_versions - platform_supported_ruby_versions
+      platform_supported_ruby_versions.each do |v|
+        assert(
+          gemspec.required_ruby_version.satisfied_by?(Gem::Version.new(v)),
+          "required_ruby_version='#{gemspec.required_ruby_version}' should support ruby #{v}",
+        )
+      end
+      unsupported_versions.each do |v|
+        refute(
+          gemspec.required_ruby_version.satisfied_by?(Gem::Version.new(v)),
+          "required_ruby_version='#{gemspec.required_ruby_version}' should not support ruby #{v}",
+        )
+      end
+    end
+  end if gemspec.platform.is_a?(Gem::Platform) && gemspec.platform.cpu
+end

--- a/script/test-gem-install
+++ b/script/test-gem-install
@@ -1,0 +1,41 @@
+#! /usr/bin/env bash
+#
+#  run as part of CI, see gem-install.yml
+#
+if [[ $# -lt 1 ]] ; then
+  echo "usage: $(basename $0) <gems_dir> [install_flags]"
+  exit 1
+fi
+
+GEMS_DIR=$1
+shift
+INSTALL_FLAGS=$*
+
+test -e /etc/os-release && cat /etc/os-release
+
+set -e -x -u
+
+pushd $GEMS_DIR
+
+  gemfile=$(ls *.gem | head -n1)
+  ls -l ${gemfile}
+  gem install --no-document ${gemfile} -- ${INSTALL_FLAGS}
+  gem list -d commonmarker
+  commonmarker -v
+
+popd
+
+if [ -n "${BUNDLE_APP_CONFIG:-}" ] ; then
+  export BUNDLE_CACHE_PATH="${BUNDLE_APP_CONFIG}/cache"
+fi
+
+gem install bundler -v "~> 2.2, != 2.3.21"
+bundle install --local || bundle install
+
+rm -rf lib ext # ensure we don't use the local files
+rake test
+
+./script/test-gem-installation
+
+# delete the Gemfile because that's confusing to older versions of rubygems (e.g., bionic32)
+rm -f Gemfile Gemfile.lock

--- a/script/test-gem-installation
+++ b/script/test-gem-installation
@@ -1,0 +1,74 @@
+#! /usr/bin/env ruby
+# frozen_string_literal: true
+
+#
+#  this script is intended to run as part of the CI test suite.
+#
+#  it inspects the filesystem of a commonmarker gem installation to ensure it's complete, and
+#  doesn't install anything we don't expect.
+#
+#  this file isn't in the `test/` subdirectory because it's intended to be run standalone against an
+#  installed gem (and not against the source code or behavior of the gem itself).
+#
+
+# this line needs to come before the bundler bit, to assert that we're running against an
+# already-installed version (and not some other version that bundler/inline might install if it came
+# first)
+gemspec = Gem::Specification.find_all_by_name("commonmarker").sort_by(&:version).last
+raise "could not find installed gem" unless gemspec
+
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "minitest"
+  gem "minitest-reporters"
+  gem "commonmarker"
+end
+
+require "commonmarker"
+require "yaml"
+
+if ARGV.include?("-v")
+  puts "---------- Commonmarker version info ----------"
+  puts Commonmarker::VERSION
+  puts
+  puts "---------- Commonmarker installed gemspec ----------"
+  puts gemspec.to_ruby
+  puts
+end
+
+require "minitest/autorun"
+require "minitest/reporters"
+Minitest::Reporters.use!([Minitest::Reporters::SpecReporter.new])
+
+puts "Testing #{gemspec.full_name} installed in #{gemspec.base_dir}"
+describe gemspec.full_name do
+  let(:ruby_maj_min) { Gem::Version.new(::RUBY_VERSION).segments[0..1].join(".") }
+  let(:commonmarker_lib_dir) { File.join(gemspec.gem_dir, "lib/commonmarker") }
+  let(:commonmarker_ext_dir) { File.join(gemspec.gem_dir, "ext/commonmarker") }
+  let(:commonmarker_include_dir) { File.join(commonmarker_ext_dir, "include") }
+
+  # representative sample of the files
+  let(:commonmarker_header_files) { ["commonmarker.h"] }
+  let(:packaged_library_header_files) { ["comrak_ffi.h"] }
+
+  it "loads the same version as the spec we've loaded" do
+    assert_equal(Commonmarker::VERSION, gemspec.version.to_s)
+  end
+
+  describe "cruby" do
+    it "installs commonmarker headers" do
+      commonmarker_header_files.each do |header|
+        assert(File.file?(File.join(commonmarker_ext_dir, header)),
+          "expected #{header} to be installed in #{commonmarker_ext_dir}")
+
+        found = false
+        headers_dirs.each do |header_dir|
+          found = true if File.file?(File.join(header_dir, "commonmarker.h"))
+        end
+        assert(found, "expected to find commonmarker.h in one of: #{headers_dirs.inspect}")
+      end
+    end
+  end
+end

--- a/script/test-has-rust
+++ b/script/test-has-rust
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+#
+#  run as part of CI, see gem-install.yml
+#
+set -e
+set -u -x
+
+if ! command -v cargo &> /dev/null; then
+  echo "cargo not found, fetching..."
+  curl https://sh.rustup.rs -sSf > rustup.sh
+  bash rustup.sh -y
+fi

--- a/test/benchmark.rb
+++ b/test/benchmark.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "benchmark/ips"
+require "commonmarker"
+require "redcarpet"
+require "kramdown"
+require "kramdown-parser-gfm"
+require "benchmark"
+
+benchinput = File.read("test/benchinput.md").freeze
+
+printf("input size = %<bytes>d bytes\n\n", { bytes: benchinput.bytesize })
+
+Benchmark.ips do |x|
+  x.report("redcarpet") do
+    Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: true, strikethrough: true, footnotes: true).render(benchinput)
+  end
+
+  x.report("commonmarker with to_html") do
+    Commonmarker.to_html(benchinput)
+  end
+
+  x.report("kramdown") do
+    Kramdown::Document.new(benchinput, input: "GFM").to_html
+  end
+
+  x.compare!
+end

--- a/test/fixtures/curly.md
+++ b/test/fixtures/curly.md
@@ -1,0 +1,1 @@
+This curly quote “makes commonmarker throw an exception”.

--- a/test/fixtures/dingus.md
+++ b/test/fixtures/dingus.md
@@ -1,0 +1,10 @@
+## Try CommonMark
+
+You can try CommonMark here.  This dingus is powered by
+[commonmark.js](https://github.com/jgm/commonmark.js), the
+JavaScript reference implementation.
+
+1. item one
+2. item two
+   - sublist
+   - sublist

--- a/test/fixtures/strong.md
+++ b/test/fixtures/strong.md
@@ -1,0 +1,1 @@
+I am **strong**

--- a/test/fixtures/table.md
+++ b/test/fixtures/table.md
@@ -1,0 +1,10 @@
+One extension:
+
+| a   | b   |
+| --- | --- |
+| c   | d   |
+| **x** | |
+
+Another extension:
+
+~~hi~~

--- a/test/fixtures/upstream/smart_punct.txt
+++ b/test/fixtures/upstream/smart_punct.txt
@@ -1,0 +1,177 @@
+## Smart punctuation
+
+Open quotes are matched with closed quotes.
+The same method is used for matching openers and closers
+as is used in emphasis parsing:
+
+```````````````````````````````` example
+"Hello," said the spider.
+"'Shelob' is my name."
+.
+<p>“Hello,” said the spider.
+“‘Shelob’ is my name.”</p>
+````````````````````````````````
+
+```````````````````````````````` example
+'A', 'B', and 'C' are letters.
+.
+<p>‘A’, ‘B’, and ‘C’ are letters.</p>
+````````````````````````````````
+
+```````````````````````````````` example
+'Oak,' 'elm,' and 'beech' are names of trees.
+So is 'pine.'
+.
+<p>‘Oak,’ ‘elm,’ and ‘beech’ are names of trees.
+So is ‘pine.’</p>
+````````````````````````````````
+
+```````````````````````````````` example
+'He said, "I want to go."'
+.
+<p>‘He said, “I want to go.”’</p>
+````````````````````````````````
+
+A single quote that isn't an open quote matched
+with a close quote will be treated as an
+apostrophe:
+
+```````````````````````````````` example
+Were you alive in the 70's?
+.
+<p>Were you alive in the 70’s?</p>
+````````````````````````````````
+
+```````````````````````````````` example
+Here is some quoted '`code`' and a "[quoted link](url)".
+.
+<p>Here is some quoted ‘<code>code</code>’ and a “<a href="url">quoted link</a>”.</p>
+````````````````````````````````
+
+Here the first `'` is treated as an apostrophe, not
+an open quote, because the final single quote is matched
+by the single quote before `jolly`:
+
+```````````````````````````````` example
+'tis the season to be 'jolly'
+.
+<p>’tis the season to be ‘jolly’</p>
+````````````````````````````````
+
+Multiple apostrophes should not be marked as open/closing quotes.
+
+```````````````````````````````` example
+'We'll use Jane's boat and John's truck,' Jenna said.
+.
+<p>‘We’ll use Jane’s boat and John’s truck,’ Jenna said.</p>
+````````````````````````````````
+
+An unmatched double quote will be interpreted as a
+left double quote, to facilitate this style:
+
+```````````````````````````````` example
+"A paragraph with no closing quote.
+
+"Second paragraph by same speaker, in fiction."
+.
+<p>“A paragraph with no closing quote.</p>
+<p>“Second paragraph by same speaker, in fiction.”</p>
+````````````````````````````````
+
+A quote following a `]` or `)` character cannot
+be an open quote:
+
+```````````````````````````````` example
+[a]'s b'
+.
+<p>[a]’s b’</p>
+````````````````````````````````
+
+Quotes that are escaped come out as literal straight
+quotes:
+
+```````````````````````````````` example
+\"This is not smart.\"
+This isn\'t either.
+5\'8\"
+.
+<p>&quot;This is not smart.&quot;
+This isn't either.
+5'8&quot;</p>
+````````````````````````````````
+
+Two hyphens form an en-dash, three an em-dash.
+
+```````````````````````````````` example
+Some dashes:  em---em
+en--en
+em --- em
+en -- en
+2--3
+.
+<p>Some dashes:  em—em
+en–en
+em — em
+en – en
+2–3</p>
+````````````````````````````````
+
+A sequence of more than three hyphens is
+parsed as a sequence of em and/or en dashes,
+with no hyphens. If possible, a homogeneous
+sequence of dashes is used (so, 10 hyphens
+= 5 en dashes, and 9 hyphens = 3 em dashes).
+When a heterogeneous sequence must be used,
+the em dashes come first, followed by the en
+dashes, and as few en dashes as possible are
+used (so, 7 hyphens = 2 em dashes an 1 en
+dash).
+
+```````````````````````````````` example
+one-
+two--
+three---
+four----
+five-----
+six------
+seven-------
+eight--------
+nine---------
+thirteen-------------.
+.
+<p>one-
+two–
+three—
+four––
+five—–
+six——
+seven—––
+eight––––
+nine———
+thirteen———––.</p>
+````````````````````````````````
+
+Hyphens can be escaped:
+
+```````````````````````````````` example
+Escaped hyphens: \-- \-\-\-.
+.
+<p>Escaped hyphens: -- ---.</p>
+````````````````````````````````
+
+Three periods form an ellipsis:
+
+```````````````````````````````` example
+Ellipses...and...and....
+.
+<p>Ellipses…and…and….</p>
+````````````````````````````````
+
+Periods can be escaped if ellipsis-formation
+is not wanted:
+
+```````````````````````````````` example
+No ellipses\.\.\.
+.
+<p>No ellipses...</p>
+````````````````````````````````

--- a/test/fixtures/upstream/spec.txt
+++ b/test/fixtures/upstream/spec.txt
@@ -1,0 +1,10226 @@
+---
+title: GitHub Flavored Markdown Spec
+version: 0.29
+date: '2019-04-06'
+license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
+...
+
+# Introduction
+
+## What is GitHub Flavored Markdown?
+
+GitHub Flavored Markdown, often shortened as GFM, is the dialect of Markdown
+that is currently supported for user content on GitHub.com and GitHub
+Enterprise.
+
+This formal specification, based on the CommonMark Spec, defines the syntax and
+semantics of this dialect.
+
+GFM is a strict superset of CommonMark. All the features which are supported in
+GitHub user content and that are not specified on the original CommonMark Spec
+are hence known as **extensions**, and highlighted as such.
+
+While GFM supports a wide range of inputs, it's worth noting that GitHub.com
+and GitHub Enterprise perform additional post-processing and sanitization after
+GFM is converted to HTML to ensure security and consistency of the website.
+
+## What is Markdown?
+
+Markdown is a plain text format for writing structured documents,
+based on conventions for indicating formatting in email
+and usenet posts.  It was developed by John Gruber (with
+help from Aaron Swartz) and released in 2004 in the form of a
+[syntax description](http://daringfireball.net/projects/markdown/syntax)
+and a Perl script (`Markdown.pl`) for converting Markdown to
+HTML.  In the next decade, dozens of implementations were
+developed in many languages.  Some extended the original
+Markdown syntax with conventions for footnotes, tables, and
+other document elements.  Some allowed Markdown documents to be
+rendered in formats other than HTML.  Websites like Reddit,
+StackOverflow, and GitHub had millions of people using Markdown.
+And Markdown started to be used beyond the web, to author books,
+articles, slide shows, letters, and lecture notes.
+
+What distinguishes Markdown from many other lightweight markup
+syntaxes, which are often easier to write, is its readability.
+As Gruber writes:
+
+> The overriding design goal for Markdown's formatting syntax is
+> to make it as readable as possible. The idea is that a
+> Markdown-formatted document should be publishable as-is, as
+> plain text, without looking like it's been marked up with tags
+> or formatting instructions.
+> (<http://daringfireball.net/projects/markdown/>)
+
+The point can be illustrated by comparing a sample of
+[AsciiDoc](http://www.methods.co.nz/asciidoc/) with
+an equivalent sample of Markdown.  Here is a sample of
+AsciiDoc from the AsciiDoc manual:
+
+```
+1. List item one.
++
+List item one continued with a second paragraph followed by an
+Indented block.
++
+.................
+$ ls *.sh
+$ mv *.sh ~/tmp
+.................
++
+List item continued with a third paragraph.
+
+2. List item two continued with an open block.
++
+--
+This paragraph is part of the preceding list item.
+
+a. This list is nested and does not require explicit item
+continuation.
++
+This paragraph is part of the preceding list item.
+
+b. List item b.
+
+This paragraph belongs to item two of the outer list.
+--
+```
+
+And here is the equivalent in Markdown:
+```
+1.  List item one.
+
+    List item one continued with a second paragraph followed by an
+    Indented block.
+
+        $ ls *.sh
+        $ mv *.sh ~/tmp
+
+    List item continued with a third paragraph.
+
+2.  List item two continued with an open block.
+
+    This paragraph is part of the preceding list item.
+
+    1. This list is nested and does not require explicit item continuation.
+
+       This paragraph is part of the preceding list item.
+
+    2. List item b.
+
+    This paragraph belongs to item two of the outer list.
+```
+
+The AsciiDoc version is, arguably, easier to write. You don't need
+to worry about indentation.  But the Markdown version is much easier
+to read.  The nesting of list items is apparent to the eye in the
+source, not just in the processed document.
+
+## Why is a spec needed?
+
+John Gruber's [canonical description of Markdown's
+syntax](http://daringfireball.net/projects/markdown/syntax)
+does not specify the syntax unambiguously.  Here are some examples of
+questions it does not answer:
+
+1.  How much indentation is needed for a sublist?  The spec says that
+    continuation paragraphs need to be indented four spaces, but is
+    not fully explicit about sublists.  It is natural to think that
+    they, too, must be indented four spaces, but `Markdown.pl` does
+    not require that.  This is hardly a "corner case," and divergences
+    between implementations on this issue often lead to surprises for
+    users in real documents. (See [this comment by John
+    Gruber](http://article.gmane.org/gmane.text.markdown.general/1997).)
+
+2.  Is a blank line needed before a block quote or heading?
+    Most implementations do not require the blank line.  However,
+    this can lead to unexpected results in hard-wrapped text, and
+    also to ambiguities in parsing (note that some implementations
+    put the heading inside the blockquote, while others do not).
+    (John Gruber has also spoken [in favor of requiring the blank
+    lines](http://article.gmane.org/gmane.text.markdown.general/2146).)
+
+3.  Is a blank line needed before an indented code block?
+    (`Markdown.pl` requires it, but this is not mentioned in the
+    documentation, and some implementations do not require it.)
+
+    ``` markdown
+    paragraph
+        code?
+    ```
+
+4.  What is the exact rule for determining when list items get
+    wrapped in `<p>` tags?  Can a list be partially "loose" and partially
+    "tight"?  What should we do with a list like this?
+
+    ``` markdown
+    1. one
+
+    2. two
+    3. three
+    ```
+
+    Or this?
+
+    ``` markdown
+    1.  one
+        - a
+
+        - b
+    2.  two
+    ```
+
+    (There are some relevant comments by John Gruber
+    [here](http://article.gmane.org/gmane.text.markdown.general/2554).)
+
+5.  Can list markers be indented?  Can ordered list markers be right-aligned?
+
+    ``` markdown
+     8. item 1
+     9. item 2
+    10. item 2a
+    ```
+
+6.  Is this one list with a thematic break in its second item,
+    or two lists separated by a thematic break?
+
+    ``` markdown
+    * a
+    * * * * *
+    * b
+    ```
+
+7.  When list markers change from numbers to bullets, do we have
+    two lists or one?  (The Markdown syntax description suggests two,
+    but the perl scripts and many other implementations produce one.)
+
+    ``` markdown
+    1. fee
+    2. fie
+    -  foe
+    -  fum
+    ```
+
+8.  What are the precedence rules for the markers of inline structure?
+    For example, is the following a valid link, or does the code span
+    take precedence ?
+
+    ``` markdown
+    [a backtick (`)](/url) and [another backtick (`)](/url).
+    ```
+
+9.  What are the precedence rules for markers of emphasis and strong
+    emphasis?  For example, how should the following be parsed?
+
+    ``` markdown
+    *foo *bar* baz*
+    ```
+
+10. What are the precedence rules between block-level and inline-level
+    structure?  For example, how should the following be parsed?
+
+    ``` markdown
+    - `a long code span can contain a hyphen like this
+      - and it can screw things up`
+    ```
+
+11. Can list items include section headings?  (`Markdown.pl` does not
+    allow this, but does allow blockquotes to include headings.)
+
+    ``` markdown
+    - # Heading
+    ```
+
+12. Can list items be empty?
+
+    ``` markdown
+    * a
+    *
+    * b
+    ```
+
+13. Can link references be defined inside block quotes or list items?
+
+    ``` markdown
+    > Blockquote [foo].
+    >
+    > [foo]: /url
+    ```
+
+14. If there are multiple definitions for the same reference, which takes
+    precedence?
+
+    ``` markdown
+    [foo]: /url1
+    [foo]: /url2
+
+    [foo][]
+    ```
+
+In the absence of a spec, early implementers consulted `Markdown.pl`
+to resolve these ambiguities.  But `Markdown.pl` was quite buggy, and
+gave manifestly bad results in many cases, so it was not a
+satisfactory replacement for a spec.
+
+Because there is no unambiguous spec, implementations have diverged
+considerably.  As a result, users are often surprised to find that
+a document that renders one way on one system (say, a GitHub wiki)
+renders differently on another (say, converting to docbook using
+pandoc).  To make matters worse, because nothing in Markdown counts
+as a "syntax error," the divergence often isn't discovered right away.
+
+## About this document
+
+This document attempts to specify Markdown syntax unambiguously.
+It contains many examples with side-by-side Markdown and
+HTML.  These are intended to double as conformance tests.  An
+accompanying script `spec_tests.py` can be used to run the tests
+against any Markdown program:
+
+    python test/spec_tests.py --spec spec.txt --program PROGRAM
+
+Since this document describes how Markdown is to be parsed into
+an abstract syntax tree, it would have made sense to use an abstract
+representation of the syntax tree instead of HTML.  But HTML is capable
+of representing the structural distinctions we need to make, and the
+choice of HTML for the tests makes it possible to run the tests against
+an implementation without writing an abstract syntax tree renderer.
+
+This document is generated from a text file, `spec.txt`, written
+in Markdown with a small extension for the side-by-side tests.
+The script `tools/makespec.py` can be used to convert `spec.txt` into
+HTML or CommonMark (which can then be converted into other formats).
+
+In the examples, the `→` character is used to represent tabs.
+
+# Preliminaries
+
+## Characters and lines
+
+Any sequence of [characters] is a valid CommonMark
+document.
+
+A [character](@) is a Unicode code point.  Although some
+code points (for example, combining accents) do not correspond to
+characters in an intuitive sense, all code points count as characters
+for purposes of this spec.
+
+This spec does not specify an encoding; it thinks of lines as composed
+of [characters] rather than bytes.  A conforming parser may be limited
+to a certain encoding.
+
+A [line](@) is a sequence of zero or more [characters]
+other than newline (`U+000A`) or carriage return (`U+000D`),
+followed by a [line ending] or by the end of file.
+
+A [line ending](@) is a newline (`U+000A`), a carriage return
+(`U+000D`) not followed by a newline, or a carriage return and a
+following newline.
+
+A line containing no characters, or a line containing only spaces
+(`U+0020`) or tabs (`U+0009`), is called a [blank line](@).
+
+The following definitions of character classes will be used in this spec:
+
+A [whitespace character](@) is a space
+(`U+0020`), tab (`U+0009`), newline (`U+000A`), line tabulation (`U+000B`),
+form feed (`U+000C`), or carriage return (`U+000D`).
+
+[Whitespace](@) is a sequence of one or more [whitespace
+characters].
+
+A [Unicode whitespace character](@) is
+any code point in the Unicode `Zs` general category, or a tab (`U+0009`),
+carriage return (`U+000D`), newline (`U+000A`), or form feed
+(`U+000C`).
+
+[Unicode whitespace](@) is a sequence of one
+or more [Unicode whitespace characters].
+
+A [space](@) is `U+0020`.
+
+A [non-whitespace character](@) is any character
+that is not a [whitespace character].
+
+An [ASCII punctuation character](@)
+is `!`, `"`, `#`, `$`, `%`, `&`, `'`, `(`, `)`,
+`*`, `+`, `,`, `-`, `.`, `/` (U+0021–2F), 
+`:`, `;`, `<`, `=`, `>`, `?`, `@` (U+003A–0040),
+`[`, `\`, `]`, `^`, `_`, `` ` `` (U+005B–0060), 
+`{`, `|`, `}`, or `~` (U+007B–007E).
+
+A [punctuation character](@) is an [ASCII
+punctuation character] or anything in
+the general Unicode categories  `Pc`, `Pd`, `Pe`, `Pf`, `Pi`, `Po`, or `Ps`.
+
+## Tabs
+
+Tabs in lines are not expanded to [spaces].  However,
+in contexts where whitespace helps to define block structure,
+tabs behave as if they were replaced by spaces with a tab stop
+of 4 characters.
+
+Thus, for example, a tab can be used instead of four spaces
+in an indented code block.  (Note, however, that internal
+tabs are passed through as literal tabs, not expanded to
+spaces.)
+
+```````````````````````````````` example
+→foo→baz→→bim
+.
+<pre><code>foo→baz→→bim
+</code></pre>
+````````````````````````````````
+
+```````````````````````````````` example
+  →foo→baz→→bim
+.
+<pre><code>foo→baz→→bim
+</code></pre>
+````````````````````````````````
+
+```````````````````````````````` example
+    a→a
+    ὐ→a
+.
+<pre><code>a→a
+ὐ→a
+</code></pre>
+````````````````````````````````
+
+In the following example, a continuation paragraph of a list
+item is indented with a tab; this has exactly the same effect
+as indentation with four spaces would:
+
+```````````````````````````````` example
+  - foo
+
+→bar
+.
+<ul>
+<li>
+<p>foo</p>
+<p>bar</p>
+</li>
+</ul>
+````````````````````````````````
+
+```````````````````````````````` example
+- foo
+
+→→bar
+.
+<ul>
+<li>
+<p>foo</p>
+<pre><code>  bar
+</code></pre>
+</li>
+</ul>
+````````````````````````````````
+
+Normally the `>` that begins a block quote may be followed
+optionally by a space, which is not considered part of the
+content.  In the following case `>` is followed by a tab,
+which is treated as if it were expanded into three spaces.
+Since one of these spaces is considered part of the
+delimiter, `foo` is considered to be indented six spaces
+inside the block quote context, so we get an indented
+code block starting with two spaces.
+
+```````````````````````````````` example
+>→→foo
+.
+<blockquote>
+<pre><code>  foo
+</code></pre>
+</blockquote>
+````````````````````````````````
+
+```````````````````````````````` example
+-→→foo
+.
+<ul>
+<li>
+<pre><code>  foo
+</code></pre>
+</li>
+</ul>
+````````````````````````````````
+
+
+```````````````````````````````` example
+    foo
+→bar
+.
+<pre><code>foo
+bar
+</code></pre>
+````````````````````````````````
+
+```````````````````````````````` example
+ - foo
+   - bar
+→ - baz
+.
+<ul>
+<li>foo
+<ul>
+<li>bar
+<ul>
+<li>baz</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+````````````````````````````````
+
+```````````````````````````````` example
+#→Foo
+.
+<h1>Foo</h1>
+````````````````````````````````
+
+```````````````````````````````` example
+*→*→*→
+.
+<hr />
+````````````````````````````````
+
+
+## Insecure characters
+
+For security reasons, the Unicode character `U+0000` must be replaced
+with the REPLACEMENT CHARACTER (`U+FFFD`).
+
+# Blocks and inlines
+
+We can think of a document as a sequence of
+[blocks](@)---structural elements like paragraphs, block
+quotations, lists, headings, rules, and code blocks.  Some blocks (like
+block quotes and list items) contain other blocks; others (like
+headings and paragraphs) contain [inline](@) content---text,
+links, emphasized text, images, code spans, and so on.
+
+## Precedence
+
+Indicators of block structure always take precedence over indicators
+of inline structure.  So, for example, the following is a list with
+two items, not a list with one item containing a code span:
+
+```````````````````````````````` example
+- `one
+- two`
+.
+<ul>
+<li>`one</li>
+<li>two`</li>
+</ul>
+````````````````````````````````
+
+
+This means that parsing can proceed in two steps:  first, the block
+structure of the document can be discerned; second, text lines inside
+paragraphs, headings, and other block constructs can be parsed for inline
+structure.  The second step requires information about link reference
+definitions that will be available only at the end of the first
+step.  Note that the first step requires processing lines in sequence,
+but the second can be parallelized, since the inline parsing of
+one block element does not affect the inline parsing of any other.
+
+## Container blocks and leaf blocks
+
+We can divide blocks into two types:
+[container blocks](@),
+which can contain other blocks, and [leaf blocks](@),
+which cannot.
+
+# Leaf blocks
+
+This section describes the different kinds of leaf block that make up a
+Markdown document.
+
+## Thematic breaks
+
+A line consisting of 0-3 spaces of indentation, followed by a sequence
+of three or more matching `-`, `_`, or `*` characters, each followed
+optionally by any number of spaces or tabs, forms a
+[thematic break](@).
+
+```````````````````````````````` example
+***
+---
+___
+.
+<hr />
+<hr />
+<hr />
+````````````````````````````````
+
+
+Wrong characters:
+
+```````````````````````````````` example
++++
+.
+<p>+++</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+===
+.
+<p>===</p>
+````````````````````````````````
+
+
+Not enough characters:
+
+```````````````````````````````` example
+--
+**
+__
+.
+<p>--
+**
+__</p>
+````````````````````````````````
+
+
+One to three spaces indent are allowed:
+
+```````````````````````````````` example
+ ***
+  ***
+   ***
+.
+<hr />
+<hr />
+<hr />
+````````````````````````````````
+
+
+Four spaces is too many:
+
+```````````````````````````````` example
+    ***
+.
+<pre><code>***
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+Foo
+    ***
+.
+<p>Foo
+***</p>
+````````````````````````````````
+
+
+More than three characters may be used:
+
+```````````````````````````````` example
+_____________________________________
+.
+<hr />
+````````````````````````````````
+
+
+Spaces are allowed between the characters:
+
+```````````````````````````````` example
+ - - -
+.
+<hr />
+````````````````````````````````
+
+
+```````````````````````````````` example
+ **  * ** * ** * **
+.
+<hr />
+````````````````````````````````
+
+
+```````````````````````````````` example
+-     -      -      -
+.
+<hr />
+````````````````````````````````
+
+
+Spaces are allowed at the end:
+
+```````````````````````````````` example
+- - - -    
+.
+<hr />
+````````````````````````````````
+
+
+However, no other characters may occur in the line:
+
+```````````````````````````````` example
+_ _ _ _ a
+
+a------
+
+---a---
+.
+<p>_ _ _ _ a</p>
+<p>a------</p>
+<p>---a---</p>
+````````````````````````````````
+
+
+It is required that all of the [non-whitespace characters] be the same.
+So, this is not a thematic break:
+
+```````````````````````````````` example
+ *-*
+.
+<p><em>-</em></p>
+````````````````````````````````
+
+
+Thematic breaks do not need blank lines before or after:
+
+```````````````````````````````` example
+- foo
+***
+- bar
+.
+<ul>
+<li>foo</li>
+</ul>
+<hr />
+<ul>
+<li>bar</li>
+</ul>
+````````````````````````````````
+
+
+Thematic breaks can interrupt a paragraph:
+
+```````````````````````````````` example
+Foo
+***
+bar
+.
+<p>Foo</p>
+<hr />
+<p>bar</p>
+````````````````````````````````
+
+
+If a line of dashes that meets the above conditions for being a
+thematic break could also be interpreted as the underline of a [setext
+heading], the interpretation as a
+[setext heading] takes precedence. Thus, for example,
+this is a setext heading, not a paragraph followed by a thematic break:
+
+```````````````````````````````` example
+Foo
+---
+bar
+.
+<h2>Foo</h2>
+<p>bar</p>
+````````````````````````````````
+
+
+When both a thematic break and a list item are possible
+interpretations of a line, the thematic break takes precedence:
+
+```````````````````````````````` example
+* Foo
+* * *
+* Bar
+.
+<ul>
+<li>Foo</li>
+</ul>
+<hr />
+<ul>
+<li>Bar</li>
+</ul>
+````````````````````````````````
+
+
+If you want a thematic break in a list item, use a different bullet:
+
+```````````````````````````````` example
+- Foo
+- * * *
+.
+<ul>
+<li>Foo</li>
+<li>
+<hr />
+</li>
+</ul>
+````````````````````````````````
+
+
+## ATX headings
+
+An [ATX heading](@)
+consists of a string of characters, parsed as inline content, between an
+opening sequence of 1--6 unescaped `#` characters and an optional
+closing sequence of any number of unescaped `#` characters.
+The opening sequence of `#` characters must be followed by a
+[space] or by the end of line. The optional closing sequence of `#`s must be
+preceded by a [space] and may be followed by spaces only.  The opening
+`#` character may be indented 0-3 spaces.  The raw contents of the
+heading are stripped of leading and trailing spaces before being parsed
+as inline content.  The heading level is equal to the number of `#`
+characters in the opening sequence.
+
+Simple headings:
+
+```````````````````````````````` example
+# foo
+## foo
+### foo
+#### foo
+##### foo
+###### foo
+.
+<h1>foo</h1>
+<h2>foo</h2>
+<h3>foo</h3>
+<h4>foo</h4>
+<h5>foo</h5>
+<h6>foo</h6>
+````````````````````````````````
+
+
+More than six `#` characters is not a heading:
+
+```````````````````````````````` example
+####### foo
+.
+<p>####### foo</p>
+````````````````````````````````
+
+
+At least one space is required between the `#` characters and the
+heading's contents, unless the heading is empty.  Note that many
+implementations currently do not require the space.  However, the
+space was required by the
+[original ATX implementation](http://www.aaronsw.com/2002/atx/atx.py),
+and it helps prevent things like the following from being parsed as
+headings:
+
+```````````````````````````````` example
+#5 bolt
+
+#hashtag
+.
+<p>#5 bolt</p>
+<p>#hashtag</p>
+````````````````````````````````
+
+
+This is not a heading, because the first `#` is escaped:
+
+```````````````````````````````` example
+\## foo
+.
+<p>## foo</p>
+````````````````````````````````
+
+
+Contents are parsed as inlines:
+
+```````````````````````````````` example
+# foo *bar* \*baz\*
+.
+<h1>foo <em>bar</em> *baz*</h1>
+````````````````````````````````
+
+
+Leading and trailing [whitespace] is ignored in parsing inline content:
+
+```````````````````````````````` example
+#                  foo                     
+.
+<h1>foo</h1>
+````````````````````````````````
+
+
+One to three spaces indentation are allowed:
+
+```````````````````````````````` example
+ ### foo
+  ## foo
+   # foo
+.
+<h3>foo</h3>
+<h2>foo</h2>
+<h1>foo</h1>
+````````````````````````````````
+
+
+Four spaces are too much:
+
+```````````````````````````````` example
+    # foo
+.
+<pre><code># foo
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo
+    # bar
+.
+<p>foo
+# bar</p>
+````````````````````````````````
+
+
+A closing sequence of `#` characters is optional:
+
+```````````````````````````````` example
+## foo ##
+  ###   bar    ###
+.
+<h2>foo</h2>
+<h3>bar</h3>
+````````````````````````````````
+
+
+It need not be the same length as the opening sequence:
+
+```````````````````````````````` example
+# foo ##################################
+##### foo ##
+.
+<h1>foo</h1>
+<h5>foo</h5>
+````````````````````````````````
+
+
+Spaces are allowed after the closing sequence:
+
+```````````````````````````````` example
+### foo ###     
+.
+<h3>foo</h3>
+````````````````````````````````
+
+
+A sequence of `#` characters with anything but [spaces] following it
+is not a closing sequence, but counts as part of the contents of the
+heading:
+
+```````````````````````````````` example
+### foo ### b
+.
+<h3>foo ### b</h3>
+````````````````````````````````
+
+
+The closing sequence must be preceded by a space:
+
+```````````````````````````````` example
+# foo#
+.
+<h1>foo#</h1>
+````````````````````````````````
+
+
+Backslash-escaped `#` characters do not count as part
+of the closing sequence:
+
+```````````````````````````````` example
+### foo \###
+## foo #\##
+# foo \#
+.
+<h3>foo ###</h3>
+<h2>foo ###</h2>
+<h1>foo #</h1>
+````````````````````````````````
+
+
+ATX headings need not be separated from surrounding content by blank
+lines, and they can interrupt paragraphs:
+
+```````````````````````````````` example
+****
+## foo
+****
+.
+<hr />
+<h2>foo</h2>
+<hr />
+````````````````````````````````
+
+
+```````````````````````````````` example
+Foo bar
+# baz
+Bar foo
+.
+<p>Foo bar</p>
+<h1>baz</h1>
+<p>Bar foo</p>
+````````````````````````````````
+
+
+ATX headings can be empty:
+
+```````````````````````````````` example
+## 
+#
+### ###
+.
+<h2></h2>
+<h1></h1>
+<h3></h3>
+````````````````````````````````
+
+
+## Setext headings
+
+A [setext heading](@) consists of one or more
+lines of text, each containing at least one [non-whitespace
+character], with no more than 3 spaces indentation, followed by
+a [setext heading underline].  The lines of text must be such
+that, were they not followed by the setext heading underline,
+they would be interpreted as a paragraph:  they cannot be
+interpretable as a [code fence], [ATX heading][ATX headings],
+[block quote][block quotes], [thematic break][thematic breaks],
+[list item][list items], or [HTML block][HTML blocks].
+
+A [setext heading underline](@) is a sequence of
+`=` characters or a sequence of `-` characters, with no more than 3
+spaces indentation and any number of trailing spaces.  If a line
+containing a single `-` can be interpreted as an
+empty [list items], it should be interpreted this way
+and not as a [setext heading underline].
+
+The heading is a level 1 heading if `=` characters are used in
+the [setext heading underline], and a level 2 heading if `-`
+characters are used.  The contents of the heading are the result
+of parsing the preceding lines of text as CommonMark inline
+content.
+
+In general, a setext heading need not be preceded or followed by a
+blank line.  However, it cannot interrupt a paragraph, so when a
+setext heading comes after a paragraph, a blank line is needed between
+them.
+
+Simple examples:
+
+```````````````````````````````` example
+Foo *bar*
+=========
+
+Foo *bar*
+---------
+.
+<h1>Foo <em>bar</em></h1>
+<h2>Foo <em>bar</em></h2>
+````````````````````````````````
+
+
+The content of the header may span more than one line:
+
+```````````````````````````````` example
+Foo *bar
+baz*
+====
+.
+<h1>Foo <em>bar
+baz</em></h1>
+````````````````````````````````
+
+The contents are the result of parsing the headings's raw
+content as inlines.  The heading's raw content is formed by
+concatenating the lines and removing initial and final
+[whitespace].
+
+```````````````````````````````` example
+  Foo *bar
+baz*→
+====
+.
+<h1>Foo <em>bar
+baz</em></h1>
+````````````````````````````````
+
+
+The underlining can be any length:
+
+```````````````````````````````` example
+Foo
+-------------------------
+
+Foo
+=
+.
+<h2>Foo</h2>
+<h1>Foo</h1>
+````````````````````````````````
+
+
+The heading content can be indented up to three spaces, and need
+not line up with the underlining:
+
+```````````````````````````````` example
+   Foo
+---
+
+  Foo
+-----
+
+  Foo
+  ===
+.
+<h2>Foo</h2>
+<h2>Foo</h2>
+<h1>Foo</h1>
+````````````````````````````````
+
+
+Four spaces indent is too much:
+
+```````````````````````````````` example
+    Foo
+    ---
+
+    Foo
+---
+.
+<pre><code>Foo
+---
+
+Foo
+</code></pre>
+<hr />
+````````````````````````````````
+
+
+The setext heading underline can be indented up to three spaces, and
+may have trailing spaces:
+
+```````````````````````````````` example
+Foo
+   ----      
+.
+<h2>Foo</h2>
+````````````````````````````````
+
+
+Four spaces is too much:
+
+```````````````````````````````` example
+Foo
+    ---
+.
+<p>Foo
+---</p>
+````````````````````````````````
+
+
+The setext heading underline cannot contain internal spaces:
+
+```````````````````````````````` example
+Foo
+= =
+
+Foo
+--- -
+.
+<p>Foo
+= =</p>
+<p>Foo</p>
+<hr />
+````````````````````````````````
+
+
+Trailing spaces in the content line do not cause a line break:
+
+```````````````````````````````` example
+Foo  
+-----
+.
+<h2>Foo</h2>
+````````````````````````````````
+
+
+Nor does a backslash at the end:
+
+```````````````````````````````` example
+Foo\
+----
+.
+<h2>Foo\</h2>
+````````````````````````````````
+
+
+Since indicators of block structure take precedence over
+indicators of inline structure, the following are setext headings:
+
+```````````````````````````````` example
+`Foo
+----
+`
+
+<a title="a lot
+---
+of dashes"/>
+.
+<h2>`Foo</h2>
+<p>`</p>
+<h2>&lt;a title=&quot;a lot</h2>
+<p>of dashes&quot;/&gt;</p>
+````````````````````````````````
+
+
+The setext heading underline cannot be a [lazy continuation
+line] in a list item or block quote:
+
+```````````````````````````````` example
+> Foo
+---
+.
+<blockquote>
+<p>Foo</p>
+</blockquote>
+<hr />
+````````````````````````````````
+
+
+```````````````````````````````` example
+> foo
+bar
+===
+.
+<blockquote>
+<p>foo
+bar
+===</p>
+</blockquote>
+````````````````````````````````
+
+
+```````````````````````````````` example
+- Foo
+---
+.
+<ul>
+<li>Foo</li>
+</ul>
+<hr />
+````````````````````````````````
+
+
+A blank line is needed between a paragraph and a following
+setext heading, since otherwise the paragraph becomes part
+of the heading's content:
+
+```````````````````````````````` example
+Foo
+Bar
+---
+.
+<h2>Foo
+Bar</h2>
+````````````````````````````````
+
+
+But in general a blank line is not required before or after
+setext headings:
+
+```````````````````````````````` example
+---
+Foo
+---
+Bar
+---
+Baz
+.
+<hr />
+<h2>Foo</h2>
+<h2>Bar</h2>
+<p>Baz</p>
+````````````````````````````````
+
+
+Setext headings cannot be empty:
+
+```````````````````````````````` example
+
+====
+.
+<p>====</p>
+````````````````````````````````
+
+
+Setext heading text lines must not be interpretable as block
+constructs other than paragraphs.  So, the line of dashes
+in these examples gets interpreted as a thematic break:
+
+```````````````````````````````` example
+---
+---
+.
+<hr />
+<hr />
+````````````````````````````````
+
+
+```````````````````````````````` example
+- foo
+-----
+.
+<ul>
+<li>foo</li>
+</ul>
+<hr />
+````````````````````````````````
+
+
+```````````````````````````````` example
+    foo
+---
+.
+<pre><code>foo
+</code></pre>
+<hr />
+````````````````````````````````
+
+
+```````````````````````````````` example
+> foo
+-----
+.
+<blockquote>
+<p>foo</p>
+</blockquote>
+<hr />
+````````````````````````````````
+
+
+If you want a heading with `> foo` as its literal text, you can
+use backslash escapes:
+
+```````````````````````````````` example
+\> foo
+------
+.
+<h2>&gt; foo</h2>
+````````````````````````````````
+
+
+**Compatibility note:**  Most existing Markdown implementations
+do not allow the text of setext headings to span multiple lines.
+But there is no consensus about how to interpret
+
+``` markdown
+Foo
+bar
+---
+baz
+```
+
+One can find four different interpretations:
+
+1. paragraph "Foo", heading "bar", paragraph "baz"
+2. paragraph "Foo bar", thematic break, paragraph "baz"
+3. paragraph "Foo bar --- baz"
+4. heading "Foo bar", paragraph "baz"
+
+We find interpretation 4 most natural, and interpretation 4
+increases the expressive power of CommonMark, by allowing
+multiline headings.  Authors who want interpretation 1 can
+put a blank line after the first paragraph:
+
+```````````````````````````````` example
+Foo
+
+bar
+---
+baz
+.
+<p>Foo</p>
+<h2>bar</h2>
+<p>baz</p>
+````````````````````````````````
+
+
+Authors who want interpretation 2 can put blank lines around
+the thematic break,
+
+```````````````````````````````` example
+Foo
+bar
+
+---
+
+baz
+.
+<p>Foo
+bar</p>
+<hr />
+<p>baz</p>
+````````````````````````````````
+
+
+or use a thematic break that cannot count as a [setext heading
+underline], such as
+
+```````````````````````````````` example
+Foo
+bar
+* * *
+baz
+.
+<p>Foo
+bar</p>
+<hr />
+<p>baz</p>
+````````````````````````````````
+
+
+Authors who want interpretation 3 can use backslash escapes:
+
+```````````````````````````````` example
+Foo
+bar
+\---
+baz
+.
+<p>Foo
+bar
+---
+baz</p>
+````````````````````````````````
+
+
+## Indented code blocks
+
+An [indented code block](@) is composed of one or more
+[indented chunks] separated by blank lines.
+An [indented chunk](@) is a sequence of non-blank lines,
+each indented four or more spaces. The contents of the code block are
+the literal contents of the lines, including trailing
+[line endings], minus four spaces of indentation.
+An indented code block has no [info string].
+
+An indented code block cannot interrupt a paragraph, so there must be
+a blank line between a paragraph and a following indented code block.
+(A blank line is not needed, however, between a code block and a following
+paragraph.)
+
+```````````````````````````````` example
+    a simple
+      indented code block
+.
+<pre><code>a simple
+  indented code block
+</code></pre>
+````````````````````````````````
+
+
+If there is any ambiguity between an interpretation of indentation
+as a code block and as indicating that material belongs to a [list
+item][list items], the list item interpretation takes precedence:
+
+```````````````````````````````` example
+  - foo
+
+    bar
+.
+<ul>
+<li>
+<p>foo</p>
+<p>bar</p>
+</li>
+</ul>
+````````````````````````````````
+
+
+```````````````````````````````` example
+1.  foo
+
+    - bar
+.
+<ol>
+<li>
+<p>foo</p>
+<ul>
+<li>bar</li>
+</ul>
+</li>
+</ol>
+````````````````````````````````
+
+
+
+The contents of a code block are literal text, and do not get parsed
+as Markdown:
+
+```````````````````````````````` example
+    <a/>
+    *hi*
+
+    - one
+.
+<pre><code>&lt;a/&gt;
+*hi*
+
+- one
+</code></pre>
+````````````````````````````````
+
+
+Here we have three chunks separated by blank lines:
+
+```````````````````````````````` example
+    chunk1
+
+    chunk2
+  
+ 
+ 
+    chunk3
+.
+<pre><code>chunk1
+
+chunk2
+
+
+
+chunk3
+</code></pre>
+````````````````````````````````
+
+
+Any initial spaces beyond four will be included in the content, even
+in interior blank lines:
+
+```````````````````````````````` example
+    chunk1
+      
+      chunk2
+.
+<pre><code>chunk1
+  
+  chunk2
+</code></pre>
+````````````````````````````````
+
+
+An indented code block cannot interrupt a paragraph.  (This
+allows hanging indents and the like.)
+
+```````````````````````````````` example
+Foo
+    bar
+
+.
+<p>Foo
+bar</p>
+````````````````````````````````
+
+
+However, any non-blank line with fewer than four leading spaces ends
+the code block immediately.  So a paragraph may occur immediately
+after indented code:
+
+```````````````````````````````` example
+    foo
+bar
+.
+<pre><code>foo
+</code></pre>
+<p>bar</p>
+````````````````````````````````
+
+
+And indented code can occur immediately before and after other kinds of
+blocks:
+
+```````````````````````````````` example
+# Heading
+    foo
+Heading
+------
+    foo
+----
+.
+<h1>Heading</h1>
+<pre><code>foo
+</code></pre>
+<h2>Heading</h2>
+<pre><code>foo
+</code></pre>
+<hr />
+````````````````````````````````
+
+
+The first line can be indented more than four spaces:
+
+```````````````````````````````` example
+        foo
+    bar
+.
+<pre><code>    foo
+bar
+</code></pre>
+````````````````````````````````
+
+
+Blank lines preceding or following an indented code block
+are not included in it:
+
+```````````````````````````````` example
+
+    
+    foo
+    
+
+.
+<pre><code>foo
+</code></pre>
+````````````````````````````````
+
+
+Trailing spaces are included in the code block's content:
+
+```````````````````````````````` example
+    foo  
+.
+<pre><code>foo  
+</code></pre>
+````````````````````````````````
+
+
+
+## Fenced code blocks
+
+A [code fence](@) is a sequence
+of at least three consecutive backtick characters (`` ` ``) or
+tildes (`~`).  (Tildes and backticks cannot be mixed.)
+A [fenced code block](@)
+begins with a code fence, indented no more than three spaces.
+
+The line with the opening code fence may optionally contain some text
+following the code fence; this is trimmed of leading and trailing
+whitespace and called the [info string](@). If the [info string] comes
+after a backtick fence, it may not contain any backtick
+characters.  (The reason for this restriction is that otherwise
+some inline code would be incorrectly interpreted as the
+beginning of a fenced code block.)
+
+The content of the code block consists of all subsequent lines, until
+a closing [code fence] of the same type as the code block
+began with (backticks or tildes), and with at least as many backticks
+or tildes as the opening code fence.  If the leading code fence is
+indented N spaces, then up to N spaces of indentation are removed from
+each line of the content (if present).  (If a content line is not
+indented, it is preserved unchanged.  If it is indented less than N
+spaces, all of the indentation is removed.)
+
+The closing code fence may be indented up to three spaces, and may be
+followed only by spaces, which are ignored.  If the end of the
+containing block (or document) is reached and no closing code fence
+has been found, the code block contains all of the lines after the
+opening code fence until the end of the containing block (or
+document).  (An alternative spec would require backtracking in the
+event that a closing code fence is not found.  But this makes parsing
+much less efficient, and there seems to be no real down side to the
+behavior described here.)
+
+A fenced code block may interrupt a paragraph, and does not require
+a blank line either before or after.
+
+The content of a code fence is treated as literal text, not parsed
+as inlines.  The first word of the [info string] is typically used to
+specify the language of the code sample, and rendered in the `class`
+attribute of the `code` tag.  However, this spec does not mandate any
+particular treatment of the [info string].
+
+Here is a simple example with backticks:
+
+```````````````````````````````` example
+```
+<
+ >
+```
+.
+<pre><code>&lt;
+ &gt;
+</code></pre>
+````````````````````````````````
+
+
+With tildes:
+
+```````````````````````````````` example
+~~~
+<
+ >
+~~~
+.
+<pre><code>&lt;
+ &gt;
+</code></pre>
+````````````````````````````````
+
+Fewer than three backticks is not enough:
+
+```````````````````````````````` example
+``
+foo
+``
+.
+<p><code>foo</code></p>
+````````````````````````````````
+
+The closing code fence must use the same character as the opening
+fence:
+
+```````````````````````````````` example
+```
+aaa
+~~~
+```
+.
+<pre><code>aaa
+~~~
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+~~~
+aaa
+```
+~~~
+.
+<pre><code>aaa
+```
+</code></pre>
+````````````````````````````````
+
+
+The closing code fence must be at least as long as the opening fence:
+
+```````````````````````````````` example
+````
+aaa
+```
+``````
+.
+<pre><code>aaa
+```
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+~~~~
+aaa
+~~~
+~~~~
+.
+<pre><code>aaa
+~~~
+</code></pre>
+````````````````````````````````
+
+
+Unclosed code blocks are closed by the end of the document
+(or the enclosing [block quote][block quotes] or [list item][list items]):
+
+```````````````````````````````` example
+```
+.
+<pre><code></code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+`````
+
+```
+aaa
+.
+<pre><code>
+```
+aaa
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+> ```
+> aaa
+
+bbb
+.
+<blockquote>
+<pre><code>aaa
+</code></pre>
+</blockquote>
+<p>bbb</p>
+````````````````````````````````
+
+
+A code block can have all empty lines as its content:
+
+```````````````````````````````` example
+```
+
+  
+```
+.
+<pre><code>
+  
+</code></pre>
+````````````````````````````````
+
+
+A code block can be empty:
+
+```````````````````````````````` example
+```
+```
+.
+<pre><code></code></pre>
+````````````````````````````````
+
+
+Fences can be indented.  If the opening fence is indented,
+content lines will have equivalent opening indentation removed,
+if present:
+
+```````````````````````````````` example
+ ```
+ aaa
+aaa
+```
+.
+<pre><code>aaa
+aaa
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+  ```
+aaa
+  aaa
+aaa
+  ```
+.
+<pre><code>aaa
+aaa
+aaa
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+   ```
+   aaa
+    aaa
+  aaa
+   ```
+.
+<pre><code>aaa
+ aaa
+aaa
+</code></pre>
+````````````````````````````````
+
+
+Four spaces indentation produces an indented code block:
+
+```````````````````````````````` example
+    ```
+    aaa
+    ```
+.
+<pre><code>```
+aaa
+```
+</code></pre>
+````````````````````````````````
+
+
+Closing fences may be indented by 0-3 spaces, and their indentation
+need not match that of the opening fence:
+
+```````````````````````````````` example
+```
+aaa
+  ```
+.
+<pre><code>aaa
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+   ```
+aaa
+  ```
+.
+<pre><code>aaa
+</code></pre>
+````````````````````````````````
+
+
+This is not a closing fence, because it is indented 4 spaces:
+
+```````````````````````````````` example
+```
+aaa
+    ```
+.
+<pre><code>aaa
+    ```
+</code></pre>
+````````````````````````````````
+
+
+
+Code fences (opening and closing) cannot contain internal spaces:
+
+```````````````````````````````` example
+``` ```
+aaa
+.
+<p><code> </code>
+aaa</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+~~~~~~
+aaa
+~~~ ~~
+.
+<pre><code>aaa
+~~~ ~~
+</code></pre>
+````````````````````````````````
+
+
+Fenced code blocks can interrupt paragraphs, and can be followed
+directly by paragraphs, without a blank line between:
+
+```````````````````````````````` example
+foo
+```
+bar
+```
+baz
+.
+<p>foo</p>
+<pre><code>bar
+</code></pre>
+<p>baz</p>
+````````````````````````````````
+
+
+Other blocks can also occur before and after fenced code blocks
+without an intervening blank line:
+
+```````````````````````````````` example
+foo
+---
+~~~
+bar
+~~~
+# baz
+.
+<h2>foo</h2>
+<pre><code>bar
+</code></pre>
+<h1>baz</h1>
+````````````````````````````````
+
+
+An [info string] can be provided after the opening code fence.
+Although this spec doesn't mandate any particular treatment of
+the info string, the first word is typically used to specify
+the language of the code block. In HTML output, the language is
+normally indicated by adding a class to the `code` element consisting
+of `language-` followed by the language name.
+
+```````````````````````````````` example
+```ruby
+def foo(x)
+  return 3
+end
+```
+.
+<pre><code class="language-ruby">def foo(x)
+  return 3
+end
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+~~~~    ruby startline=3 $%@#$
+def foo(x)
+  return 3
+end
+~~~~~~~
+.
+<pre><code class="language-ruby">def foo(x)
+  return 3
+end
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+````;
+````
+.
+<pre><code class="language-;"></code></pre>
+````````````````````````````````
+
+
+[Info strings] for backtick code blocks cannot contain backticks:
+
+```````````````````````````````` example
+``` aa ```
+foo
+.
+<p><code>aa</code>
+foo</p>
+````````````````````````````````
+
+
+[Info strings] for tilde code blocks can contain backticks and tildes:
+
+```````````````````````````````` example
+~~~ aa ``` ~~~
+foo
+~~~
+.
+<pre><code class="language-aa">foo
+</code></pre>
+````````````````````````````````
+
+
+Closing code fences cannot have [info strings]:
+
+```````````````````````````````` example
+```
+``` aaa
+```
+.
+<pre><code>``` aaa
+</code></pre>
+````````````````````````````````
+
+
+
+## HTML blocks
+
+An [HTML block](@) is a group of lines that is treated
+as raw HTML (and will not be escaped in HTML output).
+
+There are seven kinds of [HTML block], which can be defined by their
+start and end conditions.  The block begins with a line that meets a
+[start condition](@) (after up to three spaces optional indentation).
+It ends with the first subsequent line that meets a matching [end
+condition](@), or the last line of the document, or the last line of
+the [container block](#container-blocks) containing the current HTML
+block, if no line is encountered that meets the [end condition].  If
+the first line meets both the [start condition] and the [end
+condition], the block will contain just that line.
+
+1.  **Start condition:**  line begins with the string `<script`,
+`<pre`, or `<style` (case-insensitive), followed by whitespace,
+the string `>`, or the end of the line.\
+**End condition:**  line contains an end tag
+`</script>`, `</pre>`, or `</style>` (case-insensitive; it
+need not match the start tag).
+
+2.  **Start condition:** line begins with the string `<!--`.\
+**End condition:**  line contains the string `-->`.
+
+3.  **Start condition:** line begins with the string `<?`.\
+**End condition:** line contains the string `?>`.
+
+4.  **Start condition:** line begins with the string `<!`
+followed by an uppercase ASCII letter.\
+**End condition:** line contains the character `>`.
+
+5.  **Start condition:**  line begins with the string
+`<![CDATA[`.\
+**End condition:** line contains the string `]]>`.
+
+6.  **Start condition:** line begins the string `<` or `</`
+followed by one of the strings (case-insensitive) `address`,
+`article`, `aside`, `base`, `basefont`, `blockquote`, `body`,
+`caption`, `center`, `col`, `colgroup`, `dd`, `details`, `dialog`,
+`dir`, `div`, `dl`, `dt`, `fieldset`, `figcaption`, `figure`,
+`footer`, `form`, `frame`, `frameset`,
+`h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `head`, `header`, `hr`,
+`html`, `iframe`, `legend`, `li`, `link`, `main`, `menu`, `menuitem`,
+`nav`, `noframes`, `ol`, `optgroup`, `option`, `p`, `param`,
+`section`, `source`, `summary`, `table`, `tbody`, `td`,
+`tfoot`, `th`, `thead`, `title`, `tr`, `track`, `ul`, followed
+by [whitespace], the end of the line, the string `>`, or
+the string `/>`.\
+**End condition:** line is followed by a [blank line].
+
+7.  **Start condition:**  line begins with a complete [open tag]
+(with any [tag name] other than `script`,
+`style`, or `pre`) or a complete [closing tag],
+followed only by [whitespace] or the end of the line.\
+**End condition:** line is followed by a [blank line].
+
+HTML blocks continue until they are closed by their appropriate
+[end condition], or the last line of the document or other [container
+block](#container-blocks).  This means any HTML **within an HTML
+block** that might otherwise be recognised as a start condition will
+be ignored by the parser and passed through as-is, without changing
+the parser's state.
+
+For instance, `<pre>` within a HTML block started by `<table>` will not affect
+the parser state; as the HTML block was started in by start condition 6, it
+will end at any blank line. This can be surprising:
+
+```````````````````````````````` example
+<table><tr><td>
+<pre>
+**Hello**,
+
+_world_.
+</pre>
+</td></tr></table>
+.
+<table><tr><td>
+<pre>
+**Hello**,
+<p><em>world</em>.
+</pre></p>
+</td></tr></table>
+````````````````````````````````
+
+In this case, the HTML block is terminated by the newline — the `**Hello**`
+text remains verbatim — and regular parsing resumes, with a paragraph,
+emphasised `world` and inline and block HTML following.
+
+All types of [HTML blocks] except type 7 may interrupt
+a paragraph.  Blocks of type 7 may not interrupt a paragraph.
+(This restriction is intended to prevent unwanted interpretation
+of long tags inside a wrapped paragraph as starting HTML blocks.)
+
+Some simple examples follow.  Here are some basic HTML blocks
+of type 6:
+
+```````````````````````````````` example
+<table>
+  <tr>
+    <td>
+           hi
+    </td>
+  </tr>
+</table>
+
+okay.
+.
+<table>
+  <tr>
+    <td>
+           hi
+    </td>
+  </tr>
+</table>
+<p>okay.</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+ <div>
+  *hello*
+         <foo><a>
+.
+ <div>
+  *hello*
+         <foo><a>
+````````````````````````````````
+
+
+A block can also start with a closing tag:
+
+```````````````````````````````` example
+</div>
+*foo*
+.
+</div>
+*foo*
+````````````````````````````````
+
+
+Here we have two HTML blocks with a Markdown paragraph between them:
+
+```````````````````````````````` example
+<DIV CLASS="foo">
+
+*Markdown*
+
+</DIV>
+.
+<DIV CLASS="foo">
+<p><em>Markdown</em></p>
+</DIV>
+````````````````````````````````
+
+
+The tag on the first line can be partial, as long
+as it is split where there would be whitespace:
+
+```````````````````````````````` example
+<div id="foo"
+  class="bar">
+</div>
+.
+<div id="foo"
+  class="bar">
+</div>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<div id="foo" class="bar
+  baz">
+</div>
+.
+<div id="foo" class="bar
+  baz">
+</div>
+````````````````````````````````
+
+
+An open tag need not be closed:
+```````````````````````````````` example
+<div>
+*foo*
+
+*bar*
+.
+<div>
+*foo*
+<p><em>bar</em></p>
+````````````````````````````````
+
+
+
+A partial tag need not even be completed (garbage
+in, garbage out):
+
+```````````````````````````````` example
+<div id="foo"
+*hi*
+.
+<div id="foo"
+*hi*
+````````````````````````````````
+
+
+```````````````````````````````` example
+<div class
+foo
+.
+<div class
+foo
+````````````````````````````````
+
+
+The initial tag doesn't even need to be a valid
+tag, as long as it starts like one:
+
+```````````````````````````````` example
+<div *???-&&&-<---
+*foo*
+.
+<div *???-&&&-<---
+*foo*
+````````````````````````````````
+
+
+In type 6 blocks, the initial tag need not be on a line by
+itself:
+
+```````````````````````````````` example
+<div><a href="bar">*foo*</a></div>
+.
+<div><a href="bar">*foo*</a></div>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<table><tr><td>
+foo
+</td></tr></table>
+.
+<table><tr><td>
+foo
+</td></tr></table>
+````````````````````````````````
+
+
+Everything until the next blank line or end of document
+gets included in the HTML block.  So, in the following
+example, what looks like a Markdown code block
+is actually part of the HTML block, which continues until a blank
+line or the end of the document is reached:
+
+```````````````````````````````` example
+<div></div>
+``` c
+int x = 33;
+```
+.
+<div></div>
+``` c
+int x = 33;
+```
+````````````````````````````````
+
+
+To start an [HTML block] with a tag that is *not* in the
+list of block-level tags in (6), you must put the tag by
+itself on the first line (and it must be complete):
+
+```````````````````````````````` example
+<a href="foo">
+*bar*
+</a>
+.
+<a href="foo">
+*bar*
+</a>
+````````````````````````````````
+
+
+In type 7 blocks, the [tag name] can be anything:
+
+```````````````````````````````` example
+<Warning>
+*bar*
+</Warning>
+.
+<Warning>
+*bar*
+</Warning>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<i class="foo">
+*bar*
+</i>
+.
+<i class="foo">
+*bar*
+</i>
+````````````````````````````````
+
+
+```````````````````````````````` example
+</ins>
+*bar*
+.
+</ins>
+*bar*
+````````````````````````````````
+
+
+These rules are designed to allow us to work with tags that
+can function as either block-level or inline-level tags.
+The `<del>` tag is a nice example.  We can surround content with
+`<del>` tags in three different ways.  In this case, we get a raw
+HTML block, because the `<del>` tag is on a line by itself:
+
+```````````````````````````````` example
+<del>
+*foo*
+</del>
+.
+<del>
+*foo*
+</del>
+````````````````````````````````
+
+
+In this case, we get a raw HTML block that just includes
+the `<del>` tag (because it ends with the following blank
+line).  So the contents get interpreted as CommonMark:
+
+```````````````````````````````` example
+<del>
+
+*foo*
+
+</del>
+.
+<del>
+<p><em>foo</em></p>
+</del>
+````````````````````````````````
+
+
+Finally, in this case, the `<del>` tags are interpreted
+as [raw HTML] *inside* the CommonMark paragraph.  (Because
+the tag is not on a line by itself, we get inline HTML
+rather than an [HTML block].)
+
+```````````````````````````````` example
+<del>*foo*</del>
+.
+<p><del><em>foo</em></del></p>
+````````````````````````````````
+
+
+HTML tags designed to contain literal content
+(`script`, `style`, `pre`), comments, processing instructions,
+and declarations are treated somewhat differently.
+Instead of ending at the first blank line, these blocks
+end at the first line containing a corresponding end tag.
+As a result, these blocks can contain blank lines:
+
+A pre tag (type 1):
+
+```````````````````````````````` example
+<pre language="haskell"><code>
+import Text.HTML.TagSoup
+
+main :: IO ()
+main = print $ parseTags tags
+</code></pre>
+okay
+.
+<pre language="haskell"><code>
+import Text.HTML.TagSoup
+
+main :: IO ()
+main = print $ parseTags tags
+</code></pre>
+<p>okay</p>
+````````````````````````````````
+
+
+A script tag (type 1):
+
+```````````````````````````````` example
+<script type="text/javascript">
+// JavaScript example
+
+document.getElementById("demo").innerHTML = "Hello JavaScript!";
+</script>
+okay
+.
+<script type="text/javascript">
+// JavaScript example
+
+document.getElementById("demo").innerHTML = "Hello JavaScript!";
+</script>
+<p>okay</p>
+````````````````````````````````
+
+
+A style tag (type 1):
+
+```````````````````````````````` example
+<style
+  type="text/css">
+h1 {color:red;}
+
+p {color:blue;}
+</style>
+okay
+.
+<style
+  type="text/css">
+h1 {color:red;}
+
+p {color:blue;}
+</style>
+<p>okay</p>
+````````````````````````````````
+
+
+If there is no matching end tag, the block will end at the
+end of the document (or the enclosing [block quote][block quotes]
+or [list item][list items]):
+
+```````````````````````````````` example
+<style
+  type="text/css">
+
+foo
+.
+<style
+  type="text/css">
+
+foo
+````````````````````````````````
+
+
+```````````````````````````````` example
+> <div>
+> foo
+
+bar
+.
+<blockquote>
+<div>
+foo
+</blockquote>
+<p>bar</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+- <div>
+- foo
+.
+<ul>
+<li>
+<div>
+</li>
+<li>foo</li>
+</ul>
+````````````````````````````````
+
+
+The end tag can occur on the same line as the start tag:
+
+```````````````````````````````` example
+<style>p{color:red;}</style>
+*foo*
+.
+<style>p{color:red;}</style>
+<p><em>foo</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<!-- foo -->*bar*
+*baz*
+.
+<!-- foo -->*bar*
+<p><em>baz</em></p>
+````````````````````````````````
+
+
+Note that anything on the last line after the
+end tag will be included in the [HTML block]:
+
+```````````````````````````````` example
+<script>
+foo
+</script>1. *bar*
+.
+<script>
+foo
+</script>1. *bar*
+````````````````````````````````
+
+
+A comment (type 2):
+
+```````````````````````````````` example
+<!-- Foo
+
+bar
+   baz -->
+okay
+.
+<!-- Foo
+
+bar
+   baz -->
+<p>okay</p>
+````````````````````````````````
+
+
+
+A processing instruction (type 3):
+
+```````````````````````````````` example
+<?php
+
+  echo '>';
+
+?>
+okay
+.
+<?php
+
+  echo '>';
+
+?>
+<p>okay</p>
+````````````````````````````````
+
+
+A declaration (type 4):
+
+```````````````````````````````` example
+<!DOCTYPE html>
+.
+<!DOCTYPE html>
+````````````````````````````````
+
+
+CDATA (type 5):
+
+```````````````````````````````` example
+<![CDATA[
+function matchwo(a,b)
+{
+  if (a < b && a < 0) then {
+    return 1;
+
+  } else {
+
+    return 0;
+  }
+}
+]]>
+okay
+.
+<![CDATA[
+function matchwo(a,b)
+{
+  if (a < b && a < 0) then {
+    return 1;
+
+  } else {
+
+    return 0;
+  }
+}
+]]>
+<p>okay</p>
+````````````````````````````````
+
+
+The opening tag can be indented 1-3 spaces, but not 4:
+
+```````````````````````````````` example
+  <!-- foo -->
+
+    <!-- foo -->
+.
+  <!-- foo -->
+<pre><code>&lt;!-- foo --&gt;
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+  <div>
+
+    <div>
+.
+  <div>
+<pre><code>&lt;div&gt;
+</code></pre>
+````````````````````````````````
+
+
+An HTML block of types 1--6 can interrupt a paragraph, and need not be
+preceded by a blank line.
+
+```````````````````````````````` example
+Foo
+<div>
+bar
+</div>
+.
+<p>Foo</p>
+<div>
+bar
+</div>
+````````````````````````````````
+
+
+However, a following blank line is needed, except at the end of
+a document, and except for blocks of types 1--5, [above][HTML
+block]:
+
+```````````````````````````````` example
+<div>
+bar
+</div>
+*foo*
+.
+<div>
+bar
+</div>
+*foo*
+````````````````````````````````
+
+
+HTML blocks of type 7 cannot interrupt a paragraph:
+
+```````````````````````````````` example
+Foo
+<a href="bar">
+baz
+.
+<p>Foo
+<a href="bar">
+baz</p>
+````````````````````````````````
+
+
+This rule differs from John Gruber's original Markdown syntax
+specification, which says:
+
+> The only restrictions are that block-level HTML elements —
+> e.g. `<div>`, `<table>`, `<pre>`, `<p>`, etc. — must be separated from
+> surrounding content by blank lines, and the start and end tags of the
+> block should not be indented with tabs or spaces.
+
+In some ways Gruber's rule is more restrictive than the one given
+here:
+
+- It requires that an HTML block be preceded by a blank line.
+- It does not allow the start tag to be indented.
+- It requires a matching end tag, which it also does not allow to
+  be indented.
+
+Most Markdown implementations (including some of Gruber's own) do not
+respect all of these restrictions.
+
+There is one respect, however, in which Gruber's rule is more liberal
+than the one given here, since it allows blank lines to occur inside
+an HTML block.  There are two reasons for disallowing them here.
+First, it removes the need to parse balanced tags, which is
+expensive and can require backtracking from the end of the document
+if no matching end tag is found. Second, it provides a very simple
+and flexible way of including Markdown content inside HTML tags:
+simply separate the Markdown from the HTML using blank lines:
+
+Compare:
+
+```````````````````````````````` example
+<div>
+
+*Emphasized* text.
+
+</div>
+.
+<div>
+<p><em>Emphasized</em> text.</p>
+</div>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<div>
+*Emphasized* text.
+</div>
+.
+<div>
+*Emphasized* text.
+</div>
+````````````````````````````````
+
+
+Some Markdown implementations have adopted a convention of
+interpreting content inside tags as text if the open tag has
+the attribute `markdown=1`.  The rule given above seems a simpler and
+more elegant way of achieving the same expressive power, which is also
+much simpler to parse.
+
+The main potential drawback is that one can no longer paste HTML
+blocks into Markdown documents with 100% reliability.  However,
+*in most cases* this will work fine, because the blank lines in
+HTML are usually followed by HTML block tags.  For example:
+
+```````````````````````````````` example
+<table>
+
+<tr>
+
+<td>
+Hi
+</td>
+
+</tr>
+
+</table>
+.
+<table>
+<tr>
+<td>
+Hi
+</td>
+</tr>
+</table>
+````````````````````````````````
+
+
+There are problems, however, if the inner tags are indented
+*and* separated by spaces, as then they will be interpreted as
+an indented code block:
+
+```````````````````````````````` example
+<table>
+
+  <tr>
+
+    <td>
+      Hi
+    </td>
+
+  </tr>
+
+</table>
+.
+<table>
+  <tr>
+<pre><code>&lt;td&gt;
+  Hi
+&lt;/td&gt;
+</code></pre>
+  </tr>
+</table>
+````````````````````````````````
+
+
+Fortunately, blank lines are usually not necessary and can be
+deleted.  The exception is inside `<pre>` tags, but as described
+[above][HTML blocks], raw HTML blocks starting with `<pre>`
+*can* contain blank lines.
+
+## Link reference definitions
+
+A [link reference definition](@)
+consists of a [link label], indented up to three spaces, followed
+by a colon (`:`), optional [whitespace] (including up to one
+[line ending]), a [link destination],
+optional [whitespace] (including up to one
+[line ending]), and an optional [link
+title], which if it is present must be separated
+from the [link destination] by [whitespace].
+No further [non-whitespace characters] may occur on the line.
+
+A [link reference definition]
+does not correspond to a structural element of a document.  Instead, it
+defines a label which can be used in [reference links]
+and reference-style [images] elsewhere in the document.  [Link
+reference definitions] can come either before or after the links that use
+them.
+
+```````````````````````````````` example
+[foo]: /url "title"
+
+[foo]
+.
+<p><a href="/url" title="title">foo</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+   [foo]: 
+      /url  
+           'the title'  
+
+[foo]
+.
+<p><a href="/url" title="the title">foo</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[Foo*bar\]]:my_(url) 'title (with parens)'
+
+[Foo*bar\]]
+.
+<p><a href="my_(url)" title="title (with parens)">Foo*bar]</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[Foo bar]:
+<my url>
+'title'
+
+[Foo bar]
+.
+<p><a href="my%20url" title="title">Foo bar</a></p>
+````````````````````````````````
+
+
+The title may extend over multiple lines:
+
+```````````````````````````````` example
+[foo]: /url '
+title
+line1
+line2
+'
+
+[foo]
+.
+<p><a href="/url" title="
+title
+line1
+line2
+">foo</a></p>
+````````````````````````````````
+
+
+However, it may not contain a [blank line]:
+
+```````````````````````````````` example
+[foo]: /url 'title
+
+with blank line'
+
+[foo]
+.
+<p>[foo]: /url 'title</p>
+<p>with blank line'</p>
+<p>[foo]</p>
+````````````````````````````````
+
+
+The title may be omitted:
+
+```````````````````````````````` example
+[foo]:
+/url
+
+[foo]
+.
+<p><a href="/url">foo</a></p>
+````````````````````````````````
+
+
+The link destination may not be omitted:
+
+```````````````````````````````` example
+[foo]:
+
+[foo]
+.
+<p>[foo]:</p>
+<p>[foo]</p>
+````````````````````````````````
+
+ However, an empty link destination may be specified using
+ angle brackets:
+
+```````````````````````````````` example
+[foo]: <>
+
+[foo]
+.
+<p><a href="">foo</a></p>
+````````````````````````````````
+
+The title must be separated from the link destination by
+whitespace:
+
+```````````````````````````````` example
+[foo]: <bar>(baz)
+
+[foo]
+.
+<p>[foo]: <bar>(baz)</p>
+<p>[foo]</p>
+````````````````````````````````
+
+
+Both title and destination can contain backslash escapes
+and literal backslashes:
+
+```````````````````````````````` example
+[foo]: /url\bar\*baz "foo\"bar\baz"
+
+[foo]
+.
+<p><a href="/url%5Cbar*baz" title="foo&quot;bar\baz">foo</a></p>
+````````````````````````````````
+
+
+A link can come before its corresponding definition:
+
+```````````````````````````````` example
+[foo]
+
+[foo]: url
+.
+<p><a href="url">foo</a></p>
+````````````````````````````````
+
+
+If there are several matching definitions, the first one takes
+precedence:
+
+```````````````````````````````` example
+[foo]
+
+[foo]: first
+[foo]: second
+.
+<p><a href="first">foo</a></p>
+````````````````````````````````
+
+
+As noted in the section on [Links], matching of labels is
+case-insensitive (see [matches]).
+
+```````````````````````````````` example
+[FOO]: /url
+
+[Foo]
+.
+<p><a href="/url">Foo</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[ΑΓΩ]: /φου
+
+[αγω]
+.
+<p><a href="/%CF%86%CE%BF%CF%85">αγω</a></p>
+````````````````````````````````
+
+
+Here is a link reference definition with no corresponding link.
+It contributes nothing to the document.
+
+```````````````````````````````` example
+[foo]: /url
+.
+````````````````````````````````
+
+
+Here is another one:
+
+```````````````````````````````` example
+[
+foo
+]: /url
+bar
+.
+<p>bar</p>
+````````````````````````````````
+
+
+This is not a link reference definition, because there are
+[non-whitespace characters] after the title:
+
+```````````````````````````````` example
+[foo]: /url "title" ok
+.
+<p>[foo]: /url &quot;title&quot; ok</p>
+````````````````````````````````
+
+
+This is a link reference definition, but it has no title:
+
+```````````````````````````````` example
+[foo]: /url
+"title" ok
+.
+<p>&quot;title&quot; ok</p>
+````````````````````````````````
+
+
+This is not a link reference definition, because it is indented
+four spaces:
+
+```````````````````````````````` example
+    [foo]: /url "title"
+
+[foo]
+.
+<pre><code>[foo]: /url &quot;title&quot;
+</code></pre>
+<p>[foo]</p>
+````````````````````````````````
+
+
+This is not a link reference definition, because it occurs inside
+a code block:
+
+```````````````````````````````` example
+```
+[foo]: /url
+```
+
+[foo]
+.
+<pre><code>[foo]: /url
+</code></pre>
+<p>[foo]</p>
+````````````````````````````````
+
+
+A [link reference definition] cannot interrupt a paragraph.
+
+```````````````````````````````` example
+Foo
+[bar]: /baz
+
+[bar]
+.
+<p>Foo
+[bar]: /baz</p>
+<p>[bar]</p>
+````````````````````````````````
+
+
+However, it can directly follow other block elements, such as headings
+and thematic breaks, and it need not be followed by a blank line.
+
+```````````````````````````````` example
+# [Foo]
+[foo]: /url
+> bar
+.
+<h1><a href="/url">Foo</a></h1>
+<blockquote>
+<p>bar</p>
+</blockquote>
+````````````````````````````````
+
+```````````````````````````````` example
+[foo]: /url
+bar
+===
+[foo]
+.
+<h1>bar</h1>
+<p><a href="/url">foo</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[foo]: /url
+===
+[foo]
+.
+<p>===
+<a href="/url">foo</a></p>
+````````````````````````````````
+
+
+Several [link reference definitions]
+can occur one after another, without intervening blank lines.
+
+```````````````````````````````` example
+[foo]: /foo-url "foo"
+[bar]: /bar-url
+  "bar"
+[baz]: /baz-url
+
+[foo],
+[bar],
+[baz]
+.
+<p><a href="/foo-url" title="foo">foo</a>,
+<a href="/bar-url" title="bar">bar</a>,
+<a href="/baz-url">baz</a></p>
+````````````````````````````````
+
+
+[Link reference definitions] can occur
+inside block containers, like lists and block quotations.  They
+affect the entire document, not just the container in which they
+are defined:
+
+```````````````````````````````` example
+[foo]
+
+> [foo]: /url
+.
+<p><a href="/url">foo</a></p>
+<blockquote>
+</blockquote>
+````````````````````````````````
+
+
+Whether something is a [link reference definition] is
+independent of whether the link reference it defines is
+used in the document.  Thus, for example, the following
+document contains just a link reference definition, and
+no visible content:
+
+```````````````````````````````` example
+[foo]: /url
+.
+````````````````````````````````
+
+
+## Paragraphs
+
+A sequence of non-blank lines that cannot be interpreted as other
+kinds of blocks forms a [paragraph](@).
+The contents of the paragraph are the result of parsing the
+paragraph's raw content as inlines.  The paragraph's raw content
+is formed by concatenating the lines and removing initial and final
+[whitespace].
+
+A simple example with two paragraphs:
+
+```````````````````````````````` example
+aaa
+
+bbb
+.
+<p>aaa</p>
+<p>bbb</p>
+````````````````````````````````
+
+
+Paragraphs can contain multiple lines, but no blank lines:
+
+```````````````````````````````` example
+aaa
+bbb
+
+ccc
+ddd
+.
+<p>aaa
+bbb</p>
+<p>ccc
+ddd</p>
+````````````````````````````````
+
+
+Multiple blank lines between paragraph have no effect:
+
+```````````````````````````````` example
+aaa
+
+
+bbb
+.
+<p>aaa</p>
+<p>bbb</p>
+````````````````````````````````
+
+
+Leading spaces are skipped:
+
+```````````````````````````````` example
+  aaa
+ bbb
+.
+<p>aaa
+bbb</p>
+````````````````````````````````
+
+
+Lines after the first may be indented any amount, since indented
+code blocks cannot interrupt paragraphs.
+
+```````````````````````````````` example
+aaa
+             bbb
+                                       ccc
+.
+<p>aaa
+bbb
+ccc</p>
+````````````````````````````````
+
+
+However, the first line may be indented at most three spaces,
+or an indented code block will be triggered:
+
+```````````````````````````````` example
+   aaa
+bbb
+.
+<p>aaa
+bbb</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+    aaa
+bbb
+.
+<pre><code>aaa
+</code></pre>
+<p>bbb</p>
+````````````````````````````````
+
+
+Final spaces are stripped before inline parsing, so a paragraph
+that ends with two or more spaces will not end with a [hard line
+break]:
+
+```````````````````````````````` example
+aaa     
+bbb     
+.
+<p>aaa<br />
+bbb</p>
+````````````````````````````````
+
+
+## Blank lines
+
+[Blank lines] between block-level elements are ignored,
+except for the role they play in determining whether a [list]
+is [tight] or [loose].
+
+Blank lines at the beginning and end of the document are also ignored.
+
+```````````````````````````````` example
+  
+
+aaa
+  
+
+# aaa
+
+  
+.
+<p>aaa</p>
+<h1>aaa</h1>
+````````````````````````````````
+
+<div class="extension">
+
+## Tables (extension)
+
+GFM enables the `table` extension, where an additional leaf block type is
+available.
+
+A [table](@) is an arrangement of data with rows and columns, consisting of a
+single header row, a [delimiter row] separating the header from the data, and
+zero or more data rows.
+
+Each row consists of cells containing arbitrary text, in which [inlines] are
+parsed, separated by pipes (`|`).  A leading and trailing pipe is also
+recommended for clarity of reading, and if there's otherwise parsing ambiguity.
+Spaces between pipes and cell content are trimmed.  Block-level elements cannot
+be inserted in a table.
+
+The [delimiter row](@) consists of cells whose only content are hyphens (`-`),
+and optionally, a leading or trailing colon (`:`), or both, to indicate left,
+right, or center alignment respectively.
+
+```````````````````````````````` example table
+| foo | bar |
+| --- | --- |
+| baz | bim |
+.
+<table>
+<thead>
+<tr>
+<th>foo</th>
+<th>bar</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>baz</td>
+<td>bim</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+Cells in one column don't need to match length, though it's easier to read if
+they are. Likewise, use of leading and trailing pipes may be inconsistent:
+
+```````````````````````````````` example table
+| abc | defghi |
+:-: | -----------:
+bar | baz
+.
+<table>
+<thead>
+<tr>
+<th align="center">abc</th>
+<th align="right">defghi</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="center">bar</td>
+<td align="right">baz</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+Include a pipe in a cell's content by escaping it, including inside other
+inline spans:
+
+```````````````````````````````` example table
+| f\|oo  |
+| ------ |
+| b `\|` az |
+| b **\|** im |
+.
+<table>
+<thead>
+<tr>
+<th>f|oo</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>b <code>|</code> az</td>
+</tr>
+<tr>
+<td>b <strong>|</strong> im</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+The table is broken at the first empty line, or beginning of another
+block-level structure:
+
+```````````````````````````````` example table
+| abc | def |
+| --- | --- |
+| bar | baz |
+> bar
+.
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>bar</td>
+<td>baz</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p>bar</p>
+</blockquote>
+````````````````````````````````
+
+```````````````````````````````` example table
+| abc | def |
+| --- | --- |
+| bar | baz |
+bar
+
+bar
+.
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>bar</td>
+<td>baz</td>
+</tr>
+<tr>
+<td>bar</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+<p>bar</p>
+````````````````````````````````
+
+The header row must match the [delimiter row] in the number of cells.  If not,
+a table will not be recognized:
+
+```````````````````````````````` example table
+| abc | def |
+| --- |
+| bar |
+.
+<p>| abc | def |
+| --- |
+| bar |</p>
+````````````````````````````````
+
+The remainder of the table's rows may vary in the number of cells.  If there
+are a number of cells fewer than the number of cells in the header row, empty
+cells are inserted.  If there are greater, the excess is ignored:
+
+```````````````````````````````` example table
+| abc | def |
+| --- | --- |
+| bar |
+| bar | baz | boo |
+.
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>bar</td>
+<td></td>
+</tr>
+<tr>
+<td>bar</td>
+<td>baz</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+If there are no rows in the body, no `<tbody>` is generated in HTML output:
+
+```````````````````````````````` example table
+| abc | def |
+| --- | --- |
+.
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+</table>
+````````````````````````````````
+
+</div>
+
+# Container blocks
+
+A [container block](#container-blocks) is a block that has other
+blocks as its contents.  There are two basic kinds of container blocks:
+[block quotes] and [list items].
+[Lists] are meta-containers for [list items].
+
+We define the syntax for container blocks recursively.  The general
+form of the definition is:
+
+> If X is a sequence of blocks, then the result of
+> transforming X in such-and-such a way is a container of type Y
+> with these blocks as its content.
+
+So, we explain what counts as a block quote or list item by explaining
+how these can be *generated* from their contents. This should suffice
+to define the syntax, although it does not give a recipe for *parsing*
+these constructions.  (A recipe is provided below in the section entitled
+[A parsing strategy](#appendix-a-parsing-strategy).)
+
+## Block quotes
+
+A [block quote marker](@)
+consists of 0-3 spaces of initial indent, plus (a) the character `>` together
+with a following space, or (b) a single character `>` not followed by a space.
+
+The following rules define [block quotes]:
+
+1.  **Basic case.**  If a string of lines *Ls* constitute a sequence
+    of blocks *Bs*, then the result of prepending a [block quote
+    marker] to the beginning of each line in *Ls*
+    is a [block quote](#block-quotes) containing *Bs*.
+
+2.  **Laziness.**  If a string of lines *Ls* constitute a [block
+    quote](#block-quotes) with contents *Bs*, then the result of deleting
+    the initial [block quote marker] from one or
+    more lines in which the next [non-whitespace character] after the [block
+    quote marker] is [paragraph continuation
+    text] is a block quote with *Bs* as its content.
+    [Paragraph continuation text](@) is text
+    that will be parsed as part of the content of a paragraph, but does
+    not occur at the beginning of the paragraph.
+
+3.  **Consecutiveness.**  A document cannot contain two [block
+    quotes] in a row unless there is a [blank line] between them.
+
+Nothing else counts as a [block quote](#block-quotes).
+
+Here is a simple example:
+
+```````````````````````````````` example
+> # Foo
+> bar
+> baz
+.
+<blockquote>
+<h1>Foo</h1>
+<p>bar
+baz</p>
+</blockquote>
+````````````````````````````````
+
+
+The spaces after the `>` characters can be omitted:
+
+```````````````````````````````` example
+># Foo
+>bar
+> baz
+.
+<blockquote>
+<h1>Foo</h1>
+<p>bar
+baz</p>
+</blockquote>
+````````````````````````````````
+
+
+The `>` characters can be indented 1-3 spaces:
+
+```````````````````````````````` example
+   > # Foo
+   > bar
+ > baz
+.
+<blockquote>
+<h1>Foo</h1>
+<p>bar
+baz</p>
+</blockquote>
+````````````````````````````````
+
+
+Four spaces gives us a code block:
+
+```````````````````````````````` example
+    > # Foo
+    > bar
+    > baz
+.
+<pre><code>&gt; # Foo
+&gt; bar
+&gt; baz
+</code></pre>
+````````````````````````````````
+
+
+The Laziness clause allows us to omit the `>` before
+[paragraph continuation text]:
+
+```````````````````````````````` example
+> # Foo
+> bar
+baz
+.
+<blockquote>
+<h1>Foo</h1>
+<p>bar
+baz</p>
+</blockquote>
+````````````````````````````````
+
+
+A block quote can contain some lazy and some non-lazy
+continuation lines:
+
+```````````````````````````````` example
+> bar
+baz
+> foo
+.
+<blockquote>
+<p>bar
+baz
+foo</p>
+</blockquote>
+````````````````````````````````
+
+
+Laziness only applies to lines that would have been continuations of
+paragraphs had they been prepended with [block quote markers].
+For example, the `> ` cannot be omitted in the second line of
+
+``` markdown
+> foo
+> ---
+```
+
+without changing the meaning:
+
+```````````````````````````````` example
+> foo
+---
+.
+<blockquote>
+<p>foo</p>
+</blockquote>
+<hr />
+````````````````````````````````
+
+
+Similarly, if we omit the `> ` in the second line of
+
+``` markdown
+> - foo
+> - bar
+```
+
+then the block quote ends after the first line:
+
+```````````````````````````````` example
+> - foo
+- bar
+.
+<blockquote>
+<ul>
+<li>foo</li>
+</ul>
+</blockquote>
+<ul>
+<li>bar</li>
+</ul>
+````````````````````````````````
+
+
+For the same reason, we can't omit the `> ` in front of
+subsequent lines of an indented or fenced code block:
+
+```````````````````````````````` example
+>     foo
+    bar
+.
+<blockquote>
+<pre><code>foo
+</code></pre>
+</blockquote>
+<pre><code>bar
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+> ```
+foo
+```
+.
+<blockquote>
+<pre><code></code></pre>
+</blockquote>
+<p>foo</p>
+<pre><code></code></pre>
+````````````````````````````````
+
+
+Note that in the following case, we have a [lazy
+continuation line]:
+
+```````````````````````````````` example
+> foo
+    - bar
+.
+<blockquote>
+<p>foo
+- bar</p>
+</blockquote>
+````````````````````````````````
+
+
+To see why, note that in
+
+```markdown
+> foo
+>     - bar
+```
+
+the `- bar` is indented too far to start a list, and can't
+be an indented code block because indented code blocks cannot
+interrupt paragraphs, so it is [paragraph continuation text].
+
+A block quote can be empty:
+
+```````````````````````````````` example
+>
+.
+<blockquote>
+</blockquote>
+````````````````````````````````
+
+
+```````````````````````````````` example
+>
+>  
+> 
+.
+<blockquote>
+</blockquote>
+````````````````````````````````
+
+
+A block quote can have initial or final blank lines:
+
+```````````````````````````````` example
+>
+> foo
+>  
+.
+<blockquote>
+<p>foo</p>
+</blockquote>
+````````````````````````````````
+
+
+A blank line always separates block quotes:
+
+```````````````````````````````` example
+> foo
+
+> bar
+.
+<blockquote>
+<p>foo</p>
+</blockquote>
+<blockquote>
+<p>bar</p>
+</blockquote>
+````````````````````````````````
+
+
+(Most current Markdown implementations, including John Gruber's
+original `Markdown.pl`, will parse this example as a single block quote
+with two paragraphs.  But it seems better to allow the author to decide
+whether two block quotes or one are wanted.)
+
+Consecutiveness means that if we put these block quotes together,
+we get a single block quote:
+
+```````````````````````````````` example
+> foo
+> bar
+.
+<blockquote>
+<p>foo
+bar</p>
+</blockquote>
+````````````````````````````````
+
+
+To get a block quote with two paragraphs, use:
+
+```````````````````````````````` example
+> foo
+>
+> bar
+.
+<blockquote>
+<p>foo</p>
+<p>bar</p>
+</blockquote>
+````````````````````````````````
+
+
+Block quotes can interrupt paragraphs:
+
+```````````````````````````````` example
+foo
+> bar
+.
+<p>foo</p>
+<blockquote>
+<p>bar</p>
+</blockquote>
+````````````````````````````````
+
+
+In general, blank lines are not needed before or after block
+quotes:
+
+```````````````````````````````` example
+> aaa
+***
+> bbb
+.
+<blockquote>
+<p>aaa</p>
+</blockquote>
+<hr />
+<blockquote>
+<p>bbb</p>
+</blockquote>
+````````````````````````````````
+
+
+However, because of laziness, a blank line is needed between
+a block quote and a following paragraph:
+
+```````````````````````````````` example
+> bar
+baz
+.
+<blockquote>
+<p>bar
+baz</p>
+</blockquote>
+````````````````````````````````
+
+
+```````````````````````````````` example
+> bar
+
+baz
+.
+<blockquote>
+<p>bar</p>
+</blockquote>
+<p>baz</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+> bar
+>
+baz
+.
+<blockquote>
+<p>bar</p>
+</blockquote>
+<p>baz</p>
+````````````````````````````````
+
+
+It is a consequence of the Laziness rule that any number
+of initial `>`s may be omitted on a continuation line of a
+nested block quote:
+
+```````````````````````````````` example
+> > > foo
+bar
+.
+<blockquote>
+<blockquote>
+<blockquote>
+<p>foo
+bar</p>
+</blockquote>
+</blockquote>
+</blockquote>
+````````````````````````````````
+
+
+```````````````````````````````` example
+>>> foo
+> bar
+>>baz
+.
+<blockquote>
+<blockquote>
+<blockquote>
+<p>foo
+bar
+baz</p>
+</blockquote>
+</blockquote>
+</blockquote>
+````````````````````````````````
+
+
+When including an indented code block in a block quote,
+remember that the [block quote marker] includes
+both the `>` and a following space.  So *five spaces* are needed after
+the `>`:
+
+```````````````````````````````` example
+>     code
+
+>    not code
+.
+<blockquote>
+<pre><code>code
+</code></pre>
+</blockquote>
+<blockquote>
+<p>not code</p>
+</blockquote>
+````````````````````````````````
+
+
+
+## List items
+
+A [list marker](@) is a
+[bullet list marker] or an [ordered list marker].
+
+A [bullet list marker](@)
+is a `-`, `+`, or `*` character.
+
+An [ordered list marker](@)
+is a sequence of 1--9 arabic digits (`0-9`), followed by either a
+`.` character or a `)` character.  (The reason for the length
+limit is that with 10 digits we start seeing integer overflows
+in some browsers.)
+
+The following rules define [list items]:
+
+1.  **Basic case.**  If a sequence of lines *Ls* constitute a sequence of
+    blocks *Bs* starting with a [non-whitespace character], and *M* is a
+    list marker of width *W* followed by 1 ≤ *N* ≤ 4 spaces, then the result
+    of prepending *M* and the following spaces to the first line of
+    *Ls*, and indenting subsequent lines of *Ls* by *W + N* spaces, is a
+    list item with *Bs* as its contents.  The type of the list item
+    (bullet or ordered) is determined by the type of its list marker.
+    If the list item is ordered, then it is also assigned a start
+    number, based on the ordered list marker.
+
+    Exceptions:
+
+    1. When the first list item in a [list] interrupts
+    a paragraph---that is, when it starts on a line that would
+    otherwise count as [paragraph continuation text]---then (a)
+    the lines *Ls* must not begin with a blank line, and (b) if
+    the list item is ordered, the start number must be 1.
+    2. If any line is a [thematic break][thematic breaks] then
+       that line is not a list item.
+
+For example, let *Ls* be the lines
+
+```````````````````````````````` example
+A paragraph
+with two lines.
+
+    indented code
+
+> A block quote.
+.
+<p>A paragraph
+with two lines.</p>
+<pre><code>indented code
+</code></pre>
+<blockquote>
+<p>A block quote.</p>
+</blockquote>
+````````````````````````````````
+
+
+And let *M* be the marker `1.`, and *N* = 2.  Then rule #1 says
+that the following is an ordered list item with start number 1,
+and the same contents as *Ls*:
+
+```````````````````````````````` example
+1.  A paragraph
+    with two lines.
+
+        indented code
+
+    > A block quote.
+.
+<ol>
+<li>
+<p>A paragraph
+with two lines.</p>
+<pre><code>indented code
+</code></pre>
+<blockquote>
+<p>A block quote.</p>
+</blockquote>
+</li>
+</ol>
+````````````````````````````````
+
+
+The most important thing to notice is that the position of
+the text after the list marker determines how much indentation
+is needed in subsequent blocks in the list item.  If the list
+marker takes up two spaces, and there are three spaces between
+the list marker and the next [non-whitespace character], then blocks
+must be indented five spaces in order to fall under the list
+item.
+
+Here are some examples showing how far content must be indented to be
+put under the list item:
+
+```````````````````````````````` example
+- one
+
+ two
+.
+<ul>
+<li>one</li>
+</ul>
+<p>two</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+- one
+
+  two
+.
+<ul>
+<li>
+<p>one</p>
+<p>two</p>
+</li>
+</ul>
+````````````````````````````````
+
+
+```````````````````````````````` example
+ -    one
+
+     two
+.
+<ul>
+<li>one</li>
+</ul>
+<pre><code> two
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+ -    one
+
+      two
+.
+<ul>
+<li>
+<p>one</p>
+<p>two</p>
+</li>
+</ul>
+````````````````````````````````
+
+
+It is tempting to think of this in terms of columns:  the continuation
+blocks must be indented at least to the column of the first
+[non-whitespace character] after the list marker. However, that is not quite right.
+The spaces after the list marker determine how much relative indentation
+is needed.  Which column this indentation reaches will depend on
+how the list item is embedded in other constructions, as shown by
+this example:
+
+```````````````````````````````` example
+   > > 1.  one
+>>
+>>     two
+.
+<blockquote>
+<blockquote>
+<ol>
+<li>
+<p>one</p>
+<p>two</p>
+</li>
+</ol>
+</blockquote>
+</blockquote>
+````````````````````````````````
+
+
+Here `two` occurs in the same column as the list marker `1.`,
+but is actually contained in the list item, because there is
+sufficient indentation after the last containing blockquote marker.
+
+The converse is also possible.  In the following example, the word `two`
+occurs far to the right of the initial text of the list item, `one`, but
+it is not considered part of the list item, because it is not indented
+far enough past the blockquote marker:
+
+```````````````````````````````` example
+>>- one
+>>
+  >  > two
+.
+<blockquote>
+<blockquote>
+<ul>
+<li>one</li>
+</ul>
+<p>two</p>
+</blockquote>
+</blockquote>
+````````````````````````````````
+
+
+Note that at least one space is needed between the list marker and
+any following content, so these are not list items:
+
+```````````````````````````````` example
+-one
+
+2.two
+.
+<p>-one</p>
+<p>2.two</p>
+````````````````````````````````
+
+
+A list item may contain blocks that are separated by more than
+one blank line.
+
+```````````````````````````````` example
+- foo
+
+
+  bar
+.
+<ul>
+<li>
+<p>foo</p>
+<p>bar</p>
+</li>
+</ul>
+````````````````````````````````
+
+
+A list item may contain any kind of block:
+
+```````````````````````````````` example
+1.  foo
+
+    ```
+    bar
+    ```
+
+    baz
+
+    > bam
+.
+<ol>
+<li>
+<p>foo</p>
+<pre><code>bar
+</code></pre>
+<p>baz</p>
+<blockquote>
+<p>bam</p>
+</blockquote>
+</li>
+</ol>
+````````````````````````````````
+
+
+A list item that contains an indented code block will preserve
+empty lines within the code block verbatim.
+
+```````````````````````````````` example
+- Foo
+
+      bar
+
+
+      baz
+.
+<ul>
+<li>
+<p>Foo</p>
+<pre><code>bar
+
+
+baz
+</code></pre>
+</li>
+</ul>
+````````````````````````````````
+
+Note that ordered list start numbers must be nine digits or less:
+
+```````````````````````````````` example
+123456789. ok
+.
+<ol start="123456789">
+<li>ok</li>
+</ol>
+````````````````````````````````
+
+
+```````````````````````````````` example
+1234567890. not ok
+.
+<p>1234567890. not ok</p>
+````````````````````````````````
+
+
+A start number may begin with 0s:
+
+```````````````````````````````` example
+0. ok
+.
+<ol start="0">
+<li>ok</li>
+</ol>
+````````````````````````````````
+
+
+```````````````````````````````` example
+003. ok
+.
+<ol start="3">
+<li>ok</li>
+</ol>
+````````````````````````````````
+
+
+A start number may not be negative:
+
+```````````````````````````````` example
+-1. not ok
+.
+<p>-1. not ok</p>
+````````````````````````````````
+
+
+
+2.  **Item starting with indented code.**  If a sequence of lines *Ls*
+    constitute a sequence of blocks *Bs* starting with an indented code
+    block, and *M* is a list marker of width *W* followed by
+    one space, then the result of prepending *M* and the following
+    space to the first line of *Ls*, and indenting subsequent lines of
+    *Ls* by *W + 1* spaces, is a list item with *Bs* as its contents.
+    If a line is empty, then it need not be indented.  The type of the
+    list item (bullet or ordered) is determined by the type of its list
+    marker.  If the list item is ordered, then it is also assigned a
+    start number, based on the ordered list marker.
+
+An indented code block will have to be indented four spaces beyond
+the edge of the region where text will be included in the list item.
+In the following case that is 6 spaces:
+
+```````````````````````````````` example
+- foo
+
+      bar
+.
+<ul>
+<li>
+<p>foo</p>
+<pre><code>bar
+</code></pre>
+</li>
+</ul>
+````````````````````````````````
+
+
+And in this case it is 11 spaces:
+
+```````````````````````````````` example
+  10.  foo
+
+           bar
+.
+<ol start="10">
+<li>
+<p>foo</p>
+<pre><code>bar
+</code></pre>
+</li>
+</ol>
+````````````````````````````````
+
+
+If the *first* block in the list item is an indented code block,
+then by rule #2, the contents must be indented *one* space after the
+list marker:
+
+```````````````````````````````` example
+    indented code
+
+paragraph
+
+    more code
+.
+<pre><code>indented code
+</code></pre>
+<p>paragraph</p>
+<pre><code>more code
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+1.     indented code
+
+   paragraph
+
+       more code
+.
+<ol>
+<li>
+<pre><code>indented code
+</code></pre>
+<p>paragraph</p>
+<pre><code>more code
+</code></pre>
+</li>
+</ol>
+````````````````````````````````
+
+
+Note that an additional space indent is interpreted as space
+inside the code block:
+
+```````````````````````````````` example
+1.      indented code
+
+   paragraph
+
+       more code
+.
+<ol>
+<li>
+<pre><code> indented code
+</code></pre>
+<p>paragraph</p>
+<pre><code>more code
+</code></pre>
+</li>
+</ol>
+````````````````````````````````
+
+
+Note that rules #1 and #2 only apply to two cases:  (a) cases
+in which the lines to be included in a list item begin with a
+[non-whitespace character], and (b) cases in which
+they begin with an indented code
+block.  In a case like the following, where the first block begins with
+a three-space indent, the rules do not allow us to form a list item by
+indenting the whole thing and prepending a list marker:
+
+```````````````````````````````` example
+   foo
+
+bar
+.
+<p>foo</p>
+<p>bar</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+-    foo
+
+  bar
+.
+<ul>
+<li>foo</li>
+</ul>
+<p>bar</p>
+````````````````````````````````
+
+
+This is not a significant restriction, because when a block begins
+with 1-3 spaces indent, the indentation can always be removed without
+a change in interpretation, allowing rule #1 to be applied.  So, in
+the above case:
+
+```````````````````````````````` example
+-  foo
+
+   bar
+.
+<ul>
+<li>
+<p>foo</p>
+<p>bar</p>
+</li>
+</ul>
+````````````````````````````````
+
+
+3.  **Item starting with a blank line.**  If a sequence of lines *Ls*
+    starting with a single [blank line] constitute a (possibly empty)
+    sequence of blocks *Bs*, not separated from each other by more than
+    one blank line, and *M* is a list marker of width *W*,
+    then the result of prepending *M* to the first line of *Ls*, and
+    indenting subsequent lines of *Ls* by *W + 1* spaces, is a list
+    item with *Bs* as its contents.
+    If a line is empty, then it need not be indented.  The type of the
+    list item (bullet or ordered) is determined by the type of its list
+    marker.  If the list item is ordered, then it is also assigned a
+    start number, based on the ordered list marker.
+
+Here are some list items that start with a blank line but are not empty:
+
+```````````````````````````````` example
+-
+  foo
+-
+  ```
+  bar
+  ```
+-
+      baz
+.
+<ul>
+<li>foo</li>
+<li>
+<pre><code>bar
+</code></pre>
+</li>
+<li>
+<pre><code>baz
+</code></pre>
+</li>
+</ul>
+````````````````````````````````
+
+When the list item starts with a blank line, the number of spaces
+following the list marker doesn't change the required indentation:
+
+```````````````````````````````` example
+-   
+  foo
+.
+<ul>
+<li>foo</li>
+</ul>
+````````````````````````````````
+
+
+A list item can begin with at most one blank line.
+In the following example, `foo` is not part of the list
+item:
+
+```````````````````````````````` example
+-
+
+  foo
+.
+<ul>
+<li></li>
+</ul>
+<p>foo</p>
+````````````````````````````````
+
+
+Here is an empty bullet list item:
+
+```````````````````````````````` example
+- foo
+-
+- bar
+.
+<ul>
+<li>foo</li>
+<li></li>
+<li>bar</li>
+</ul>
+````````````````````````````````
+
+
+It does not matter whether there are spaces following the [list marker]:
+
+```````````````````````````````` example
+- foo
+-   
+- bar
+.
+<ul>
+<li>foo</li>
+<li></li>
+<li>bar</li>
+</ul>
+````````````````````````````````
+
+
+Here is an empty ordered list item:
+
+```````````````````````````````` example
+1. foo
+2.
+3. bar
+.
+<ol>
+<li>foo</li>
+<li></li>
+<li>bar</li>
+</ol>
+````````````````````````````````
+
+
+A list may start or end with an empty list item:
+
+```````````````````````````````` example
+*
+.
+<ul>
+<li></li>
+</ul>
+````````````````````````````````
+
+However, an empty list item cannot interrupt a paragraph:
+
+```````````````````````````````` example
+foo
+*
+
+foo
+1.
+.
+<p>foo
+*</p>
+<p>foo
+1.</p>
+````````````````````````````````
+
+
+4.  **Indentation.**  If a sequence of lines *Ls* constitutes a list item
+    according to rule #1, #2, or #3, then the result of indenting each line
+    of *Ls* by 1-3 spaces (the same for each line) also constitutes a
+    list item with the same contents and attributes.  If a line is
+    empty, then it need not be indented.
+
+Indented one space:
+
+```````````````````````````````` example
+ 1.  A paragraph
+     with two lines.
+
+         indented code
+
+     > A block quote.
+.
+<ol>
+<li>
+<p>A paragraph
+with two lines.</p>
+<pre><code>indented code
+</code></pre>
+<blockquote>
+<p>A block quote.</p>
+</blockquote>
+</li>
+</ol>
+````````````````````````````````
+
+
+Indented two spaces:
+
+```````````````````````````````` example
+  1.  A paragraph
+      with two lines.
+
+          indented code
+
+      > A block quote.
+.
+<ol>
+<li>
+<p>A paragraph
+with two lines.</p>
+<pre><code>indented code
+</code></pre>
+<blockquote>
+<p>A block quote.</p>
+</blockquote>
+</li>
+</ol>
+````````````````````````````````
+
+
+Indented three spaces:
+
+```````````````````````````````` example
+   1.  A paragraph
+       with two lines.
+
+           indented code
+
+       > A block quote.
+.
+<ol>
+<li>
+<p>A paragraph
+with two lines.</p>
+<pre><code>indented code
+</code></pre>
+<blockquote>
+<p>A block quote.</p>
+</blockquote>
+</li>
+</ol>
+````````````````````````````````
+
+
+Four spaces indent gives a code block:
+
+```````````````````````````````` example
+    1.  A paragraph
+        with two lines.
+
+            indented code
+
+        > A block quote.
+.
+<pre><code>1.  A paragraph
+    with two lines.
+
+        indented code
+
+    &gt; A block quote.
+</code></pre>
+````````````````````````````````
+
+
+
+5.  **Laziness.**  If a string of lines *Ls* constitute a [list
+    item](#list-items) with contents *Bs*, then the result of deleting
+    some or all of the indentation from one or more lines in which the
+    next [non-whitespace character] after the indentation is
+    [paragraph continuation text] is a
+    list item with the same contents and attributes.  The unindented
+    lines are called
+    [lazy continuation line](@)s.
+
+Here is an example with [lazy continuation lines]:
+
+```````````````````````````````` example
+  1.  A paragraph
+with two lines.
+
+          indented code
+
+      > A block quote.
+.
+<ol>
+<li>
+<p>A paragraph
+with two lines.</p>
+<pre><code>indented code
+</code></pre>
+<blockquote>
+<p>A block quote.</p>
+</blockquote>
+</li>
+</ol>
+````````````````````````````````
+
+
+Indentation can be partially deleted:
+
+```````````````````````````````` example
+  1.  A paragraph
+    with two lines.
+.
+<ol>
+<li>A paragraph
+with two lines.</li>
+</ol>
+````````````````````````````````
+
+
+These examples show how laziness can work in nested structures:
+
+```````````````````````````````` example
+> 1. > Blockquote
+continued here.
+.
+<blockquote>
+<ol>
+<li>
+<blockquote>
+<p>Blockquote
+continued here.</p>
+</blockquote>
+</li>
+</ol>
+</blockquote>
+````````````````````````````````
+
+
+```````````````````````````````` example
+> 1. > Blockquote
+> continued here.
+.
+<blockquote>
+<ol>
+<li>
+<blockquote>
+<p>Blockquote
+continued here.</p>
+</blockquote>
+</li>
+</ol>
+</blockquote>
+````````````````````````````````
+
+
+
+6.  **That's all.** Nothing that is not counted as a list item by rules
+    #1--5 counts as a [list item](#list-items).
+
+The rules for sublists follow from the general rules
+[above][List items].  A sublist must be indented the same number
+of spaces a paragraph would need to be in order to be included
+in the list item.
+
+So, in this case we need two spaces indent:
+
+```````````````````````````````` example
+- foo
+  - bar
+    - baz
+      - boo
+.
+<ul>
+<li>foo
+<ul>
+<li>bar
+<ul>
+<li>baz
+<ul>
+<li>boo</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+````````````````````````````````
+
+
+One is not enough:
+
+```````````````````````````````` example
+- foo
+ - bar
+  - baz
+   - boo
+.
+<ul>
+<li>foo</li>
+<li>bar</li>
+<li>baz</li>
+<li>boo</li>
+</ul>
+````````````````````````````````
+
+
+Here we need four, because the list marker is wider:
+
+```````````````````````````````` example
+10) foo
+    - bar
+.
+<ol start="10">
+<li>foo
+<ul>
+<li>bar</li>
+</ul>
+</li>
+</ol>
+````````````````````````````````
+
+
+Three is not enough:
+
+```````````````````````````````` example
+10) foo
+   - bar
+.
+<ol start="10">
+<li>foo</li>
+</ol>
+<ul>
+<li>bar</li>
+</ul>
+````````````````````````````````
+
+
+A list may be the first block in a list item:
+
+```````````````````````````````` example
+- - foo
+.
+<ul>
+<li>
+<ul>
+<li>foo</li>
+</ul>
+</li>
+</ul>
+````````````````````````````````
+
+
+```````````````````````````````` example
+1. - 2. foo
+.
+<ol>
+<li>
+<ul>
+<li>
+<ol start="2">
+<li>foo</li>
+</ol>
+</li>
+</ul>
+</li>
+</ol>
+````````````````````````````````
+
+
+A list item can contain a heading:
+
+```````````````````````````````` example
+- # Foo
+- Bar
+  ---
+  baz
+.
+<ul>
+<li>
+<h1>Foo</h1>
+</li>
+<li>
+<h2>Bar</h2>
+baz</li>
+</ul>
+````````````````````````````````
+
+
+### Motivation
+
+John Gruber's Markdown spec says the following about list items:
+
+1. "List markers typically start at the left margin, but may be indented
+   by up to three spaces. List markers must be followed by one or more
+   spaces or a tab."
+
+2. "To make lists look nice, you can wrap items with hanging indents....
+   But if you don't want to, you don't have to."
+
+3. "List items may consist of multiple paragraphs. Each subsequent
+   paragraph in a list item must be indented by either 4 spaces or one
+   tab."
+
+4. "It looks nice if you indent every line of the subsequent paragraphs,
+   but here again, Markdown will allow you to be lazy."
+
+5. "To put a blockquote within a list item, the blockquote's `>`
+   delimiters need to be indented."
+
+6. "To put a code block within a list item, the code block needs to be
+   indented twice — 8 spaces or two tabs."
+
+These rules specify that a paragraph under a list item must be indented
+four spaces (presumably, from the left margin, rather than the start of
+the list marker, but this is not said), and that code under a list item
+must be indented eight spaces instead of the usual four.  They also say
+that a block quote must be indented, but not by how much; however, the
+example given has four spaces indentation.  Although nothing is said
+about other kinds of block-level content, it is certainly reasonable to
+infer that *all* block elements under a list item, including other
+lists, must be indented four spaces.  This principle has been called the
+*four-space rule*.
+
+The four-space rule is clear and principled, and if the reference
+implementation `Markdown.pl` had followed it, it probably would have
+become the standard.  However, `Markdown.pl` allowed paragraphs and
+sublists to start with only two spaces indentation, at least on the
+outer level.  Worse, its behavior was inconsistent: a sublist of an
+outer-level list needed two spaces indentation, but a sublist of this
+sublist needed three spaces.  It is not surprising, then, that different
+implementations of Markdown have developed very different rules for
+determining what comes under a list item.  (Pandoc and python-Markdown,
+for example, stuck with Gruber's syntax description and the four-space
+rule, while discount, redcarpet, marked, PHP Markdown, and others
+followed `Markdown.pl`'s behavior more closely.)
+
+Unfortunately, given the divergences between implementations, there
+is no way to give a spec for list items that will be guaranteed not
+to break any existing documents.  However, the spec given here should
+correctly handle lists formatted with either the four-space rule or
+the more forgiving `Markdown.pl` behavior, provided they are laid out
+in a way that is natural for a human to read.
+
+The strategy here is to let the width and indentation of the list marker
+determine the indentation necessary for blocks to fall under the list
+item, rather than having a fixed and arbitrary number.  The writer can
+think of the body of the list item as a unit which gets indented to the
+right enough to fit the list marker (and any indentation on the list
+marker).  (The laziness rule, #5, then allows continuation lines to be
+unindented if needed.)
+
+This rule is superior, we claim, to any rule requiring a fixed level of
+indentation from the margin.  The four-space rule is clear but
+unnatural. It is quite unintuitive that
+
+``` markdown
+- foo
+
+  bar
+
+  - baz
+```
+
+should be parsed as two lists with an intervening paragraph,
+
+``` html
+<ul>
+<li>foo</li>
+</ul>
+<p>bar</p>
+<ul>
+<li>baz</li>
+</ul>
+```
+
+as the four-space rule demands, rather than a single list,
+
+``` html
+<ul>
+<li>
+<p>foo</p>
+<p>bar</p>
+<ul>
+<li>baz</li>
+</ul>
+</li>
+</ul>
+```
+
+The choice of four spaces is arbitrary.  It can be learned, but it is
+not likely to be guessed, and it trips up beginners regularly.
+
+Would it help to adopt a two-space rule?  The problem is that such
+a rule, together with the rule allowing 1--3 spaces indentation of the
+initial list marker, allows text that is indented *less than* the
+original list marker to be included in the list item. For example,
+`Markdown.pl` parses
+
+``` markdown
+   - one
+
+  two
+```
+
+as a single list item, with `two` a continuation paragraph:
+
+``` html
+<ul>
+<li>
+<p>one</p>
+<p>two</p>
+</li>
+</ul>
+```
+
+and similarly
+
+``` markdown
+>   - one
+>
+>  two
+```
+
+as
+
+``` html
+<blockquote>
+<ul>
+<li>
+<p>one</p>
+<p>two</p>
+</li>
+</ul>
+</blockquote>
+```
+
+This is extremely unintuitive.
+
+Rather than requiring a fixed indent from the margin, we could require
+a fixed indent (say, two spaces, or even one space) from the list marker (which
+may itself be indented).  This proposal would remove the last anomaly
+discussed.  Unlike the spec presented above, it would count the following
+as a list item with a subparagraph, even though the paragraph `bar`
+is not indented as far as the first paragraph `foo`:
+
+``` markdown
+ 10. foo
+
+   bar  
+```
+
+Arguably this text does read like a list item with `bar` as a subparagraph,
+which may count in favor of the proposal.  However, on this proposal indented
+code would have to be indented six spaces after the list marker.  And this
+would break a lot of existing Markdown, which has the pattern:
+
+``` markdown
+1.  foo
+
+        indented code
+```
+
+where the code is indented eight spaces.  The spec above, by contrast, will
+parse this text as expected, since the code block's indentation is measured
+from the beginning of `foo`.
+
+The one case that needs special treatment is a list item that *starts*
+with indented code.  How much indentation is required in that case, since
+we don't have a "first paragraph" to measure from?  Rule #2 simply stipulates
+that in such cases, we require one space indentation from the list marker
+(and then the normal four spaces for the indented code).  This will match the
+four-space rule in cases where the list marker plus its initial indentation
+takes four spaces (a common case), but diverge in other cases.
+
+<div class="extension">
+
+## Task list items (extension)
+
+GFM enables the `tasklist` extension, where an additional processing step is
+performed on [list items].
+
+A [task list item](@) is a [list item][list items] where the first block in it
+is a paragraph which begins with a [task list item marker] and at least one
+whitespace character before any other content.
+
+A [task list item marker](@) consists of an optional number of spaces, a left
+bracket (`[`), either a whitespace character or the letter `x` in either
+lowercase or uppercase, and then a right bracket (`]`).
+
+When rendered, the [task list item marker] is replaced with a semantic checkbox element;
+in an HTML output, this would be an `<input type="checkbox">` element.
+
+If the character between the brackets is a whitespace character, the checkbox
+is unchecked.  Otherwise, the checkbox is checked.
+
+This spec does not define how the checkbox elements are interacted with: in practice,
+implementors are free to render the checkboxes as disabled or inmutable elements,
+or they may dynamically handle dynamic interactions (i.e. checking, unchecking) in
+the final rendered document.
+
+```````````````````````````````` example disabled
+- [ ] foo
+- [x] bar
+.
+<ul>
+<li><input type="checkbox" disabled="" /> foo</li>
+<li><input type="checkbox" disabled="" checked="" /> bar</li>
+</ul>
+````````````````````````````````
+
+Task lists can be arbitrarily nested:
+
+```````````````````````````````` example disabled
+- [x] foo
+  - [ ] bar
+  - [x] baz
+- [ ] bim
+.
+<ul>
+<li><input type="checkbox" disabled="" checked="" /> foo
+<ul>
+<li><input type="checkbox" disabled="" /> bar</li>
+<li><input type="checkbox" disabled="" checked="" /> baz</li>
+</ul>
+</li>
+<li><input type="checkbox" disabled="" /> bim</li>
+</ul>
+````````````````````````````````
+
+</div>
+
+## Lists
+
+A [list](@) is a sequence of one or more
+list items [of the same type].  The list items
+may be separated by any number of blank lines.
+
+Two list items are [of the same type](@)
+if they begin with a [list marker] of the same type.
+Two list markers are of the
+same type if (a) they are bullet list markers using the same character
+(`-`, `+`, or `*`) or (b) they are ordered list numbers with the same
+delimiter (either `.` or `)`).
+
+A list is an [ordered list](@)
+if its constituent list items begin with
+[ordered list markers], and a
+[bullet list](@) if its constituent list
+items begin with [bullet list markers].
+
+The [start number](@)
+of an [ordered list] is determined by the list number of
+its initial list item.  The numbers of subsequent list items are
+disregarded.
+
+A list is [loose](@) if any of its constituent
+list items are separated by blank lines, or if any of its constituent
+list items directly contain two block-level elements with a blank line
+between them.  Otherwise a list is [tight](@).
+(The difference in HTML output is that paragraphs in a loose list are
+wrapped in `<p>` tags, while paragraphs in a tight list are not.)
+
+Changing the bullet or ordered list delimiter starts a new list:
+
+```````````````````````````````` example
+- foo
+- bar
++ baz
+.
+<ul>
+<li>foo</li>
+<li>bar</li>
+</ul>
+<ul>
+<li>baz</li>
+</ul>
+````````````````````````````````
+
+
+```````````````````````````````` example
+1. foo
+2. bar
+3) baz
+.
+<ol>
+<li>foo</li>
+<li>bar</li>
+</ol>
+<ol start="3">
+<li>baz</li>
+</ol>
+````````````````````````````````
+
+
+In CommonMark, a list can interrupt a paragraph. That is,
+no blank line is needed to separate a paragraph from a following
+list:
+
+```````````````````````````````` example
+Foo
+- bar
+- baz
+.
+<p>Foo</p>
+<ul>
+<li>bar</li>
+<li>baz</li>
+</ul>
+````````````````````````````````
+
+`Markdown.pl` does not allow this, through fear of triggering a list
+via a numeral in a hard-wrapped line:
+
+``` markdown
+The number of windows in my house is
+14.  The number of doors is 6.
+```
+
+Oddly, though, `Markdown.pl` *does* allow a blockquote to
+interrupt a paragraph, even though the same considerations might
+apply.
+
+In CommonMark, we do allow lists to interrupt paragraphs, for
+two reasons.  First, it is natural and not uncommon for people
+to start lists without blank lines:
+
+``` markdown
+I need to buy
+- new shoes
+- a coat
+- a plane ticket
+```
+
+Second, we are attracted to a
+
+> [principle of uniformity](@):
+> if a chunk of text has a certain
+> meaning, it will continue to have the same meaning when put into a
+> container block (such as a list item or blockquote).
+
+(Indeed, the spec for [list items] and [block quotes] presupposes
+this principle.) This principle implies that if
+
+``` markdown
+  * I need to buy
+    - new shoes
+    - a coat
+    - a plane ticket
+```
+
+is a list item containing a paragraph followed by a nested sublist,
+as all Markdown implementations agree it is (though the paragraph
+may be rendered without `<p>` tags, since the list is "tight"),
+then
+
+``` markdown
+I need to buy
+- new shoes
+- a coat
+- a plane ticket
+```
+
+by itself should be a paragraph followed by a nested sublist.
+
+Since it is well established Markdown practice to allow lists to
+interrupt paragraphs inside list items, the [principle of
+uniformity] requires us to allow this outside list items as
+well.  ([reStructuredText](http://docutils.sourceforge.net/rst.html)
+takes a different approach, requiring blank lines before lists
+even inside other list items.)
+
+In order to solve of unwanted lists in paragraphs with
+hard-wrapped numerals, we allow only lists starting with `1` to
+interrupt paragraphs.  Thus,
+
+```````````````````````````````` example
+The number of windows in my house is
+14.  The number of doors is 6.
+.
+<p>The number of windows in my house is
+14.  The number of doors is 6.</p>
+````````````````````````````````
+
+We may still get an unintended result in cases like
+
+```````````````````````````````` example
+The number of windows in my house is
+1.  The number of doors is 6.
+.
+<p>The number of windows in my house is</p>
+<ol>
+<li>The number of doors is 6.</li>
+</ol>
+````````````````````````````````
+
+but this rule should prevent most spurious list captures.
+
+There can be any number of blank lines between items:
+
+```````````````````````````````` example
+- foo
+
+- bar
+
+
+- baz
+.
+<ul>
+<li>
+<p>foo</p>
+</li>
+<li>
+<p>bar</p>
+</li>
+<li>
+<p>baz</p>
+</li>
+</ul>
+````````````````````````````````
+
+```````````````````````````````` example
+- foo
+  - bar
+    - baz
+
+
+      bim
+.
+<ul>
+<li>foo
+<ul>
+<li>bar
+<ul>
+<li>
+<p>baz</p>
+<p>bim</p>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+````````````````````````````````
+
+
+To separate consecutive lists of the same type, or to separate a
+list from an indented code block that would otherwise be parsed
+as a subparagraph of the final list item, you can insert a blank HTML
+comment:
+
+```````````````````````````````` example
+- foo
+- bar
+
+<!-- -->
+
+- baz
+- bim
+.
+<ul>
+<li>foo</li>
+<li>bar</li>
+</ul>
+<!-- -->
+<ul>
+<li>baz</li>
+<li>bim</li>
+</ul>
+````````````````````````````````
+
+
+```````````````````````````````` example
+-   foo
+
+    notcode
+
+-   foo
+
+<!-- -->
+
+    code
+.
+<ul>
+<li>
+<p>foo</p>
+<p>notcode</p>
+</li>
+<li>
+<p>foo</p>
+</li>
+</ul>
+<!-- -->
+<pre><code>code
+</code></pre>
+````````````````````````````````
+
+
+List items need not be indented to the same level.  The following
+list items will be treated as items at the same list level,
+since none is indented enough to belong to the previous list
+item:
+
+```````````````````````````````` example
+- a
+ - b
+  - c
+   - d
+  - e
+ - f
+- g
+.
+<ul>
+<li>a</li>
+<li>b</li>
+<li>c</li>
+<li>d</li>
+<li>e</li>
+<li>f</li>
+<li>g</li>
+</ul>
+````````````````````````````````
+
+
+```````````````````````````````` example
+1. a
+
+  2. b
+
+   3. c
+.
+<ol>
+<li>
+<p>a</p>
+</li>
+<li>
+<p>b</p>
+</li>
+<li>
+<p>c</p>
+</li>
+</ol>
+````````````````````````````````
+
+Note, however, that list items may not be indented more than
+three spaces.  Here `- e` is treated as a paragraph continuation
+line, because it is indented more than three spaces:
+
+```````````````````````````````` example
+- a
+ - b
+  - c
+   - d
+    - e
+.
+<ul>
+<li>a</li>
+<li>b</li>
+<li>c</li>
+<li>d
+- e</li>
+</ul>
+````````````````````````````````
+
+And here, `3. c` is treated as in indented code block,
+because it is indented four spaces and preceded by a
+blank line.
+
+```````````````````````````````` example
+1. a
+
+  2. b
+
+    3. c
+.
+<ol>
+<li>
+<p>a</p>
+</li>
+<li>
+<p>b</p>
+</li>
+</ol>
+<pre><code>3. c
+</code></pre>
+````````````````````````````````
+
+
+This is a loose list, because there is a blank line between
+two of the list items:
+
+```````````````````````````````` example
+- a
+- b
+
+- c
+.
+<ul>
+<li>
+<p>a</p>
+</li>
+<li>
+<p>b</p>
+</li>
+<li>
+<p>c</p>
+</li>
+</ul>
+````````````````````````````````
+
+
+So is this, with a empty second item:
+
+```````````````````````````````` example
+* a
+*
+
+* c
+.
+<ul>
+<li>
+<p>a</p>
+</li>
+<li></li>
+<li>
+<p>c</p>
+</li>
+</ul>
+````````````````````````````````
+
+
+These are loose lists, even though there is no space between the items,
+because one of the items directly contains two block-level elements
+with a blank line between them:
+
+```````````````````````````````` example
+- a
+- b
+
+  c
+- d
+.
+<ul>
+<li>
+<p>a</p>
+</li>
+<li>
+<p>b</p>
+<p>c</p>
+</li>
+<li>
+<p>d</p>
+</li>
+</ul>
+````````````````````````````````
+
+
+```````````````````````````````` example
+- a
+- b
+
+  [ref]: /url
+- d
+.
+<ul>
+<li>
+<p>a</p>
+</li>
+<li>
+<p>b</p>
+</li>
+<li>
+<p>d</p>
+</li>
+</ul>
+````````````````````````````````
+
+
+This is a tight list, because the blank lines are in a code block:
+
+```````````````````````````````` example
+- a
+- ```
+  b
+
+
+  ```
+- c
+.
+<ul>
+<li>a</li>
+<li>
+<pre><code>b
+
+
+</code></pre>
+</li>
+<li>c</li>
+</ul>
+````````````````````````````````
+
+
+This is a tight list, because the blank line is between two
+paragraphs of a sublist.  So the sublist is loose while
+the outer list is tight:
+
+```````````````````````````````` example
+- a
+  - b
+
+    c
+- d
+.
+<ul>
+<li>a
+<ul>
+<li>
+<p>b</p>
+<p>c</p>
+</li>
+</ul>
+</li>
+<li>d</li>
+</ul>
+````````````````````````````````
+
+
+This is a tight list, because the blank line is inside the
+block quote:
+
+```````````````````````````````` example
+* a
+  > b
+  >
+* c
+.
+<ul>
+<li>a
+<blockquote>
+<p>b</p>
+</blockquote>
+</li>
+<li>c</li>
+</ul>
+````````````````````````````````
+
+
+This list is tight, because the consecutive block elements
+are not separated by blank lines:
+
+```````````````````````````````` example
+- a
+  > b
+  ```
+  c
+  ```
+- d
+.
+<ul>
+<li>a
+<blockquote>
+<p>b</p>
+</blockquote>
+<pre><code>c
+</code></pre>
+</li>
+<li>d</li>
+</ul>
+````````````````````````````````
+
+
+A single-paragraph list is tight:
+
+```````````````````````````````` example
+- a
+.
+<ul>
+<li>a</li>
+</ul>
+````````````````````````````````
+
+
+```````````````````````````````` example
+- a
+  - b
+.
+<ul>
+<li>a
+<ul>
+<li>b</li>
+</ul>
+</li>
+</ul>
+````````````````````````````````
+
+
+This list is loose, because of the blank line between the
+two block elements in the list item:
+
+```````````````````````````````` example
+1. ```
+   foo
+   ```
+
+   bar
+.
+<ol>
+<li>
+<pre><code>foo
+</code></pre>
+<p>bar</p>
+</li>
+</ol>
+````````````````````````````````
+
+
+Here the outer list is loose, the inner list tight:
+
+```````````````````````````````` example
+* foo
+  * bar
+
+  baz
+.
+<ul>
+<li>
+<p>foo</p>
+<ul>
+<li>bar</li>
+</ul>
+<p>baz</p>
+</li>
+</ul>
+````````````````````````````````
+
+
+```````````````````````````````` example
+- a
+  - b
+  - c
+
+- d
+  - e
+  - f
+.
+<ul>
+<li>
+<p>a</p>
+<ul>
+<li>b</li>
+<li>c</li>
+</ul>
+</li>
+<li>
+<p>d</p>
+<ul>
+<li>e</li>
+<li>f</li>
+</ul>
+</li>
+</ul>
+````````````````````````````````
+
+
+# Inlines
+
+Inlines are parsed sequentially from the beginning of the character
+stream to the end (left to right, in left-to-right languages).
+Thus, for example, in
+
+```````````````````````````````` example
+`hi`lo`
+.
+<p><code>hi</code>lo`</p>
+````````````````````````````````
+
+`hi` is parsed as code, leaving the backtick at the end as a literal
+backtick.
+
+
+## Backslash escapes
+
+Any ASCII punctuation character may be backslash-escaped:
+
+```````````````````````````````` example
+\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
+.
+<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~</p>
+````````````````````````````````
+
+
+Backslashes before other characters are treated as literal
+backslashes:
+
+```````````````````````````````` example
+\→\A\a\ \3\φ\«
+.
+<p>\→\A\a\ \3\φ\«</p>
+````````````````````````````````
+
+
+Escaped characters are treated as regular characters and do
+not have their usual Markdown meanings:
+
+```````````````````````````````` example
+\*not emphasized*
+\<br/> not a tag
+\[not a link](/foo)
+\`not code`
+1\. not a list
+\* not a list
+\# not a heading
+\[foo]: /url "not a reference"
+\&ouml; not a character entity
+.
+<p>*not emphasized*
+&lt;br/&gt; not a tag
+[not a link](/foo)
+`not code`
+1. not a list
+* not a list
+# not a heading
+[foo]: /url &quot;not a reference&quot;
+&amp;ouml; not a character entity</p>
+````````````````````````````````
+
+
+If a backslash is itself escaped, the following character is not:
+
+```````````````````````````````` example
+\\*emphasis*
+.
+<p>\<em>emphasis</em></p>
+````````````````````````````````
+
+
+A backslash at the end of the line is a [hard line break]:
+
+```````````````````````````````` example
+foo\
+bar
+.
+<p>foo<br />
+bar</p>
+````````````````````````````````
+
+
+Backslash escapes do not work in code blocks, code spans, autolinks, or
+raw HTML:
+
+```````````````````````````````` example
+`` \[\` ``
+.
+<p><code>\[\`</code></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+    \[\]
+.
+<pre><code>\[\]
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+~~~
+\[\]
+~~~
+.
+<pre><code>\[\]
+</code></pre>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<http://example.com?find=\*>
+.
+<p><a href="http://example.com?find=%5C*">http://example.com?find=\*</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<a href="/bar\/)">
+.
+<a href="/bar\/)">
+````````````````````````````````
+
+
+But they work in all other contexts, including URLs and link titles,
+link references, and [info strings] in [fenced code blocks]:
+
+```````````````````````````````` example
+[foo](/bar\* "ti\*tle")
+.
+<p><a href="/bar*" title="ti*tle">foo</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo]
+
+[foo]: /bar\* "ti\*tle"
+.
+<p><a href="/bar*" title="ti*tle">foo</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+``` foo\+bar
+foo
+```
+.
+<pre><code class="language-foo+bar">foo
+</code></pre>
+````````````````````````````````
+
+
+
+## Entity and numeric character references
+
+Valid HTML entity references and numeric character references
+can be used in place of the corresponding Unicode character,
+with the following exceptions:
+
+- Entity and character references are not recognized in code
+  blocks and code spans.
+
+- Entity and character references cannot stand in place of
+  special characters that define structural elements in
+  CommonMark.  For example, although `&#42;` can be used
+  in place of a literal `*` character, `&#42;` cannot replace
+  `*` in emphasis delimiters, bullet list markers, or thematic
+  breaks.
+
+Conforming CommonMark parsers need not store information about
+whether a particular character was represented in the source
+using a Unicode character or an entity reference.
+
+[Entity references](@) consist of `&` + any of the valid
+HTML5 entity names + `;`. The
+document <https://html.spec.whatwg.org/multipage/entities.json>
+is used as an authoritative source for the valid entity
+references and their corresponding code points.
+
+```````````````````````````````` example
+&nbsp; &amp; &copy; &AElig; &Dcaron;
+&frac34; &HilbertSpace; &DifferentialD;
+&ClockwiseContourIntegral; &ngE;
+.
+<p>  &amp; © Æ Ď
+¾ ℋ ⅆ
+∲ ≧̸</p>
+````````````````````````````````
+
+
+[Decimal numeric character
+references](@)
+consist of `&#` + a string of 1--7 arabic digits + `;`. A
+numeric character reference is parsed as the corresponding
+Unicode character. Invalid Unicode code points will be replaced by
+the REPLACEMENT CHARACTER (`U+FFFD`).  For security reasons,
+the code point `U+0000` will also be replaced by `U+FFFD`.
+
+```````````````````````````````` example
+&#35; &#1234; &#992; &#0;
+.
+<p># Ӓ Ϡ �</p>
+````````````````````````````````
+
+
+[Hexadecimal numeric character
+references](@) consist of `&#` +
+either `X` or `x` + a string of 1-6 hexadecimal digits + `;`.
+They too are parsed as the corresponding Unicode character (this
+time specified with a hexadecimal numeral instead of decimal).
+
+```````````````````````````````` example
+&#X22; &#XD06; &#xcab;
+.
+<p>&quot; ആ ಫ</p>
+````````````````````````````````
+
+
+Here are some nonentities:
+
+```````````````````````````````` example
+&nbsp &x; &#; &#x;
+&#987654321;
+&#abcdef0;
+&ThisIsNotDefined; &hi?;
+.
+<p>&amp;nbsp &amp;x; &amp;#; &amp;#x;
+&amp;#987654321;
+&amp;#abcdef0;
+&amp;ThisIsNotDefined; &amp;hi?;</p>
+````````````````````````````````
+
+
+Although HTML5 does accept some entity references
+without a trailing semicolon (such as `&copy`), these are not
+recognized here, because it makes the grammar too ambiguous:
+
+```````````````````````````````` example
+&copy
+.
+<p>&amp;copy</p>
+````````````````````````````````
+
+
+Strings that are not on the list of HTML5 named entities are not
+recognized as entity references either:
+
+```````````````````````````````` example
+&MadeUpEntity;
+.
+<p>&amp;MadeUpEntity;</p>
+````````````````````````````````
+
+
+Entity and numeric character references are recognized in any
+context besides code spans or code blocks, including
+URLs, [link titles], and [fenced code block][] [info strings]:
+
+```````````````````````````````` example
+<a href="&ouml;&ouml;.html">
+.
+<a href="&ouml;&ouml;.html">
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo](/f&ouml;&ouml; "f&ouml;&ouml;")
+.
+<p><a href="/f%C3%B6%C3%B6" title="föö">foo</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo]
+
+[foo]: /f&ouml;&ouml; "f&ouml;&ouml;"
+.
+<p><a href="/f%C3%B6%C3%B6" title="föö">foo</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+``` f&ouml;&ouml;
+foo
+```
+.
+<pre><code class="language-föö">foo
+</code></pre>
+````````````````````````````````
+
+
+Entity and numeric character references are treated as literal
+text in code spans and code blocks:
+
+```````````````````````````````` example
+`f&ouml;&ouml;`
+.
+<p><code>f&amp;ouml;&amp;ouml;</code></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+    f&ouml;f&ouml;
+.
+<pre><code>f&amp;ouml;f&amp;ouml;
+</code></pre>
+````````````````````````````````
+
+
+Entity and numeric character references cannot be used
+in place of symbols indicating structure in CommonMark
+documents.
+
+```````````````````````````````` example
+&#42;foo&#42;
+*foo*
+.
+<p>*foo*
+<em>foo</em></p>
+````````````````````````````````
+
+```````````````````````````````` example
+&#42; foo
+
+* foo
+.
+<p>* foo</p>
+<ul>
+<li>foo</li>
+</ul>
+````````````````````````````````
+
+```````````````````````````````` example
+foo&#10;&#10;bar
+.
+<p>foo
+
+bar</p>
+````````````````````````````````
+
+```````````````````````````````` example
+&#9;foo
+.
+<p>→foo</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[a](url &quot;tit&quot;)
+.
+<p>[a](url &quot;tit&quot;)</p>
+````````````````````````````````
+
+
+## Code spans
+
+A [backtick string](@)
+is a string of one or more backtick characters (`` ` ``) that is neither
+preceded nor followed by a backtick.
+
+A [code span](@) begins with a backtick string and ends with
+a backtick string of equal length.  The contents of the code span are
+the characters between the two backtick strings, normalized in the
+following ways:
+
+- First, [line endings] are converted to [spaces].
+- If the resulting string both begins *and* ends with a [space]
+  character, but does not consist entirely of [space]
+  characters, a single [space] character is removed from the
+  front and back.  This allows you to include code that begins
+  or ends with backtick characters, which must be separated by
+  whitespace from the opening or closing backtick strings.
+
+This is a simple code span:
+
+```````````````````````````````` example
+`foo`
+.
+<p><code>foo</code></p>
+````````````````````````````````
+
+
+Here two backticks are used, because the code contains a backtick.
+This example also illustrates stripping of a single leading and
+trailing space:
+
+```````````````````````````````` example
+`` foo ` bar ``
+.
+<p><code>foo ` bar</code></p>
+````````````````````````````````
+
+
+This example shows the motivation for stripping leading and trailing
+spaces:
+
+```````````````````````````````` example
+` `` `
+.
+<p><code>``</code></p>
+````````````````````````````````
+
+Note that only *one* space is stripped:
+
+```````````````````````````````` example
+`  ``  `
+.
+<p><code> `` </code></p>
+````````````````````````````````
+
+The stripping only happens if the space is on both
+sides of the string:
+
+```````````````````````````````` example
+` a`
+.
+<p><code> a</code></p>
+````````````````````````````````
+
+Only [spaces], and not [unicode whitespace] in general, are
+stripped in this way:
+
+```````````````````````````````` example
+` b `
+.
+<p><code> b </code></p>
+````````````````````````````````
+
+No stripping occurs if the code span contains only spaces:
+
+```````````````````````````````` example
+` `
+`  `
+.
+<p><code> </code>
+<code>  </code></p>
+````````````````````````````````
+
+
+[Line endings] are treated like spaces:
+
+```````````````````````````````` example
+``
+foo
+bar  
+baz
+``
+.
+<p><code>foo bar   baz</code></p>
+````````````````````````````````
+
+```````````````````````````````` example
+``
+foo 
+``
+.
+<p><code>foo </code></p>
+````````````````````````````````
+
+
+Interior spaces are not collapsed:
+
+```````````````````````````````` example
+`foo   bar 
+baz`
+.
+<p><code>foo   bar  baz</code></p>
+````````````````````````````````
+
+Note that browsers will typically collapse consecutive spaces
+when rendering `<code>` elements, so it is recommended that
+the following CSS be used:
+
+    code{white-space: pre-wrap;}
+
+
+Note that backslash escapes do not work in code spans. All backslashes
+are treated literally:
+
+```````````````````````````````` example
+`foo\`bar`
+.
+<p><code>foo\</code>bar`</p>
+````````````````````````````````
+
+
+Backslash escapes are never needed, because one can always choose a
+string of *n* backtick characters as delimiters, where the code does
+not contain any strings of exactly *n* backtick characters.
+
+```````````````````````````````` example
+``foo`bar``
+.
+<p><code>foo`bar</code></p>
+````````````````````````````````
+
+```````````````````````````````` example
+` foo `` bar `
+.
+<p><code>foo `` bar</code></p>
+````````````````````````````````
+
+
+Code span backticks have higher precedence than any other inline
+constructs except HTML tags and autolinks.  Thus, for example, this is
+not parsed as emphasized text, since the second `*` is part of a code
+span:
+
+```````````````````````````````` example
+*foo`*`
+.
+<p>*foo<code>*</code></p>
+````````````````````````````````
+
+
+And this is not parsed as a link:
+
+```````````````````````````````` example
+[not a `link](/foo`)
+.
+<p>[not a <code>link](/foo</code>)</p>
+````````````````````````````````
+
+
+Code spans, HTML tags, and autolinks have the same precedence.
+Thus, this is code:
+
+```````````````````````````````` example
+`<a href="`">`
+.
+<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>
+````````````````````````````````
+
+
+But this is an HTML tag:
+
+```````````````````````````````` example
+<a href="`">`
+.
+<p><a href="`">`</p>
+````````````````````````````````
+
+
+And this is code:
+
+```````````````````````````````` example
+`<http://foo.bar.`baz>`
+.
+<p><code>&lt;http://foo.bar.</code>baz&gt;`</p>
+````````````````````````````````
+
+
+But this is an autolink:
+
+```````````````````````````````` example
+<http://foo.bar.`baz>`
+.
+<p><a href="http://foo.bar.%60baz">http://foo.bar.`baz</a>`</p>
+````````````````````````````````
+
+
+When a backtick string is not closed by a matching backtick string,
+we just have literal backticks:
+
+```````````````````````````````` example
+```foo``
+.
+<p>```foo``</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+`foo
+.
+<p>`foo</p>
+````````````````````````````````
+
+The following case also illustrates the need for opening and
+closing backtick strings to be equal in length:
+
+```````````````````````````````` example
+`foo``bar``
+.
+<p>`foo<code>bar</code></p>
+````````````````````````````````
+
+
+## Emphasis and strong emphasis
+
+John Gruber's original [Markdown syntax
+description](http://daringfireball.net/projects/markdown/syntax#em) says:
+
+> Markdown treats asterisks (`*`) and underscores (`_`) as indicators of
+> emphasis. Text wrapped with one `*` or `_` will be wrapped with an HTML
+> `<em>` tag; double `*`'s or `_`'s will be wrapped with an HTML `<strong>`
+> tag.
+
+This is enough for most users, but these rules leave much undecided,
+especially when it comes to nested emphasis.  The original
+`Markdown.pl` test suite makes it clear that triple `***` and
+`___` delimiters can be used for strong emphasis, and most
+implementations have also allowed the following patterns:
+
+``` markdown
+***strong emph***
+***strong** in emph*
+***emph* in strong**
+**in strong *emph***
+*in emph **strong***
+```
+
+The following patterns are less widely supported, but the intent
+is clear and they are useful (especially in contexts like bibliography
+entries):
+
+``` markdown
+*emph *with emph* in it*
+**strong **with strong** in it**
+```
+
+Many implementations have also restricted intraword emphasis to
+the `*` forms, to avoid unwanted emphasis in words containing
+internal underscores.  (It is best practice to put these in code
+spans, but users often do not.)
+
+``` markdown
+internal emphasis: foo*bar*baz
+no emphasis: foo_bar_baz
+```
+
+The rules given below capture all of these patterns, while allowing
+for efficient parsing strategies that do not backtrack.
+
+First, some definitions.  A [delimiter run](@) is either
+a sequence of one or more `*` characters that is not preceded or
+followed by a non-backslash-escaped `*` character, or a sequence
+of one or more `_` characters that is not preceded or followed by
+a non-backslash-escaped `_` character.
+
+A [left-flanking delimiter run](@) is
+a [delimiter run] that is (1) not followed by [Unicode whitespace],
+and either (2a) not followed by a [punctuation character], or
+(2b) followed by a [punctuation character] and
+preceded by [Unicode whitespace] or a [punctuation character].
+For purposes of this definition, the beginning and the end of
+the line count as Unicode whitespace.
+
+A [right-flanking delimiter run](@) is
+a [delimiter run] that is (1) not preceded by [Unicode whitespace],
+and either (2a) not preceded by a [punctuation character], or
+(2b) preceded by a [punctuation character] and
+followed by [Unicode whitespace] or a [punctuation character].
+For purposes of this definition, the beginning and the end of
+the line count as Unicode whitespace.
+
+Here are some examples of delimiter runs.
+
+  - left-flanking but not right-flanking:
+
+    ```
+    ***abc
+      _abc
+    **"abc"
+     _"abc"
+    ```
+
+  - right-flanking but not left-flanking:
+
+    ```
+     abc***
+     abc_
+    "abc"**
+    "abc"_
+    ```
+
+  - Both left and right-flanking:
+
+    ```
+     abc***def
+    "abc"_"def"
+    ```
+
+  - Neither left nor right-flanking:
+
+    ```
+    abc *** def
+    a _ b
+    ```
+
+(The idea of distinguishing left-flanking and right-flanking
+delimiter runs based on the character before and the character
+after comes from Roopesh Chander's
+[vfmd](http://www.vfmd.org/vfmd-spec/specification/#procedure-for-identifying-emphasis-tags).
+vfmd uses the terminology "emphasis indicator string" instead of "delimiter
+run," and its rules for distinguishing left- and right-flanking runs
+are a bit more complex than the ones given here.)
+
+The following rules define emphasis and strong emphasis:
+
+1.  A single `*` character [can open emphasis](@)
+    iff (if and only if) it is part of a [left-flanking delimiter run].
+
+2.  A single `_` character [can open emphasis] iff
+    it is part of a [left-flanking delimiter run]
+    and either (a) not part of a [right-flanking delimiter run]
+    or (b) part of a [right-flanking delimiter run]
+    preceded by punctuation.
+
+3.  A single `*` character [can close emphasis](@)
+    iff it is part of a [right-flanking delimiter run].
+
+4.  A single `_` character [can close emphasis] iff
+    it is part of a [right-flanking delimiter run]
+    and either (a) not part of a [left-flanking delimiter run]
+    or (b) part of a [left-flanking delimiter run]
+    followed by punctuation.
+
+5.  A double `**` [can open strong emphasis](@)
+    iff it is part of a [left-flanking delimiter run].
+
+6.  A double `__` [can open strong emphasis] iff
+    it is part of a [left-flanking delimiter run]
+    and either (a) not part of a [right-flanking delimiter run]
+    or (b) part of a [right-flanking delimiter run]
+    preceded by punctuation.
+
+7.  A double `**` [can close strong emphasis](@)
+    iff it is part of a [right-flanking delimiter run].
+
+8.  A double `__` [can close strong emphasis] iff
+    it is part of a [right-flanking delimiter run]
+    and either (a) not part of a [left-flanking delimiter run]
+    or (b) part of a [left-flanking delimiter run]
+    followed by punctuation.
+
+9.  Emphasis begins with a delimiter that [can open emphasis] and ends
+    with a delimiter that [can close emphasis], and that uses the same
+    character (`_` or `*`) as the opening delimiter.  The
+    opening and closing delimiters must belong to separate
+    [delimiter runs].  If one of the delimiters can both
+    open and close emphasis, then the sum of the lengths of the
+    delimiter runs containing the opening and closing delimiters
+    must not be a multiple of 3 unless both lengths are
+    multiples of 3.
+
+10. Strong emphasis begins with a delimiter that
+    [can open strong emphasis] and ends with a delimiter that
+    [can close strong emphasis], and that uses the same character
+    (`_` or `*`) as the opening delimiter.  The
+    opening and closing delimiters must belong to separate
+    [delimiter runs].  If one of the delimiters can both open
+    and close strong emphasis, then the sum of the lengths of
+    the delimiter runs containing the opening and closing
+    delimiters must not be a multiple of 3 unless both lengths
+    are multiples of 3.
+
+11. A literal `*` character cannot occur at the beginning or end of
+    `*`-delimited emphasis or `**`-delimited strong emphasis, unless it
+    is backslash-escaped.
+
+12. A literal `_` character cannot occur at the beginning or end of
+    `_`-delimited emphasis or `__`-delimited strong emphasis, unless it
+    is backslash-escaped.
+
+Where rules 1--12 above are compatible with multiple parsings,
+the following principles resolve ambiguity:
+
+13. The number of nestings should be minimized. Thus, for example,
+    an interpretation `<strong>...</strong>` is always preferred to
+    `<em><em>...</em></em>`.
+
+14. An interpretation `<em><strong>...</strong></em>` is always
+    preferred to `<strong><em>...</em></strong>`.
+
+15. When two potential emphasis or strong emphasis spans overlap,
+    so that the second begins before the first ends and ends after
+    the first ends, the first takes precedence. Thus, for example,
+    `*foo _bar* baz_` is parsed as `<em>foo _bar</em> baz_` rather
+    than `*foo <em>bar* baz</em>`.
+
+16. When there are two potential emphasis or strong emphasis spans
+    with the same closing delimiter, the shorter one (the one that
+    opens later) takes precedence. Thus, for example,
+    `**foo **bar baz**` is parsed as `**foo <strong>bar baz</strong>`
+    rather than `<strong>foo **bar baz</strong>`.
+
+17. Inline code spans, links, images, and HTML tags group more tightly
+    than emphasis.  So, when there is a choice between an interpretation
+    that contains one of these elements and one that does not, the
+    former always wins.  Thus, for example, `*[foo*](bar)` is
+    parsed as `*<a href="bar">foo*</a>` rather than as
+    `<em>[foo</em>](bar)`.
+
+These rules can be illustrated through a series of examples.
+
+Rule 1:
+
+```````````````````````````````` example
+*foo bar*
+.
+<p><em>foo bar</em></p>
+````````````````````````````````
+
+
+This is not emphasis, because the opening `*` is followed by
+whitespace, and hence not part of a [left-flanking delimiter run]:
+
+```````````````````````````````` example
+a * foo bar*
+.
+<p>a * foo bar*</p>
+````````````````````````````````
+
+
+This is not emphasis, because the opening `*` is preceded
+by an alphanumeric and followed by punctuation, and hence
+not part of a [left-flanking delimiter run]:
+
+```````````````````````````````` example
+a*"foo"*
+.
+<p>a*&quot;foo&quot;*</p>
+````````````````````````````````
+
+
+Unicode nonbreaking spaces count as whitespace, too:
+
+```````````````````````````````` example
+* a *
+.
+<p>* a *</p>
+````````````````````````````````
+
+
+Intraword emphasis with `*` is permitted:
+
+```````````````````````````````` example
+foo*bar*
+.
+<p>foo<em>bar</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+5*6*78
+.
+<p>5<em>6</em>78</p>
+````````````````````````````````
+
+
+Rule 2:
+
+```````````````````````````````` example
+_foo bar_
+.
+<p><em>foo bar</em></p>
+````````````````````````````````
+
+
+This is not emphasis, because the opening `_` is followed by
+whitespace:
+
+```````````````````````````````` example
+_ foo bar_
+.
+<p>_ foo bar_</p>
+````````````````````````````````
+
+
+This is not emphasis, because the opening `_` is preceded
+by an alphanumeric and followed by punctuation:
+
+```````````````````````````````` example
+a_"foo"_
+.
+<p>a_&quot;foo&quot;_</p>
+````````````````````````````````
+
+
+Emphasis with `_` is not allowed inside words:
+
+```````````````````````````````` example
+foo_bar_
+.
+<p>foo_bar_</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+5_6_78
+.
+<p>5_6_78</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+пристаням_стремятся_
+.
+<p>пристаням_стремятся_</p>
+````````````````````````````````
+
+
+Here `_` does not generate emphasis, because the first delimiter run
+is right-flanking and the second left-flanking:
+
+```````````````````````````````` example
+aa_"bb"_cc
+.
+<p>aa_&quot;bb&quot;_cc</p>
+````````````````````````````````
+
+
+This is emphasis, even though the opening delimiter is
+both left- and right-flanking, because it is preceded by
+punctuation:
+
+```````````````````````````````` example
+foo-_(bar)_
+.
+<p>foo-<em>(bar)</em></p>
+````````````````````````````````
+
+
+Rule 3:
+
+This is not emphasis, because the closing delimiter does
+not match the opening delimiter:
+
+```````````````````````````````` example
+_foo*
+.
+<p>_foo*</p>
+````````````````````````````````
+
+
+This is not emphasis, because the closing `*` is preceded by
+whitespace:
+
+```````````````````````````````` example
+*foo bar *
+.
+<p>*foo bar *</p>
+````````````````````````````````
+
+
+A newline also counts as whitespace:
+
+```````````````````````````````` example
+*foo bar
+*
+.
+<p>*foo bar
+*</p>
+````````````````````````````````
+
+
+This is not emphasis, because the second `*` is
+preceded by punctuation and followed by an alphanumeric
+(hence it is not part of a [right-flanking delimiter run]:
+
+```````````````````````````````` example
+*(*foo)
+.
+<p>*(*foo)</p>
+````````````````````````````````
+
+
+The point of this restriction is more easily appreciated
+with this example:
+
+```````````````````````````````` example
+*(*foo*)*
+.
+<p><em>(<em>foo</em>)</em></p>
+````````````````````````````````
+
+
+Intraword emphasis with `*` is allowed:
+
+```````````````````````````````` example
+*foo*bar
+.
+<p><em>foo</em>bar</p>
+````````````````````````````````
+
+
+
+Rule 4:
+
+This is not emphasis, because the closing `_` is preceded by
+whitespace:
+
+```````````````````````````````` example
+_foo bar _
+.
+<p>_foo bar _</p>
+````````````````````````````````
+
+
+This is not emphasis, because the second `_` is
+preceded by punctuation and followed by an alphanumeric:
+
+```````````````````````````````` example
+_(_foo)
+.
+<p>_(_foo)</p>
+````````````````````````````````
+
+
+This is emphasis within emphasis:
+
+```````````````````````````````` example
+_(_foo_)_
+.
+<p><em>(<em>foo</em>)</em></p>
+````````````````````````````````
+
+
+Intraword emphasis is disallowed for `_`:
+
+```````````````````````````````` example
+_foo_bar
+.
+<p>_foo_bar</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+_пристаням_стремятся
+.
+<p>_пристаням_стремятся</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+_foo_bar_baz_
+.
+<p><em>foo_bar_baz</em></p>
+````````````````````````````````
+
+
+This is emphasis, even though the closing delimiter is
+both left- and right-flanking, because it is followed by
+punctuation:
+
+```````````````````````````````` example
+_(bar)_.
+.
+<p><em>(bar)</em>.</p>
+````````````````````````````````
+
+
+Rule 5:
+
+```````````````````````````````` example
+**foo bar**
+.
+<p><strong>foo bar</strong></p>
+````````````````````````````````
+
+
+This is not strong emphasis, because the opening delimiter is
+followed by whitespace:
+
+```````````````````````````````` example
+** foo bar**
+.
+<p>** foo bar**</p>
+````````````````````````````````
+
+
+This is not strong emphasis, because the opening `**` is preceded
+by an alphanumeric and followed by punctuation, and hence
+not part of a [left-flanking delimiter run]:
+
+```````````````````````````````` example
+a**"foo"**
+.
+<p>a**&quot;foo&quot;**</p>
+````````````````````````````````
+
+
+Intraword strong emphasis with `**` is permitted:
+
+```````````````````````````````` example
+foo**bar**
+.
+<p>foo<strong>bar</strong></p>
+````````````````````````````````
+
+
+Rule 6:
+
+```````````````````````````````` example
+__foo bar__
+.
+<p><strong>foo bar</strong></p>
+````````````````````````````````
+
+
+This is not strong emphasis, because the opening delimiter is
+followed by whitespace:
+
+```````````````````````````````` example
+__ foo bar__
+.
+<p>__ foo bar__</p>
+````````````````````````````````
+
+
+A newline counts as whitespace:
+```````````````````````````````` example
+__
+foo bar__
+.
+<p>__
+foo bar__</p>
+````````````````````````````````
+
+
+This is not strong emphasis, because the opening `__` is preceded
+by an alphanumeric and followed by punctuation:
+
+```````````````````````````````` example
+a__"foo"__
+.
+<p>a__&quot;foo&quot;__</p>
+````````````````````````````````
+
+
+Intraword strong emphasis is forbidden with `__`:
+
+```````````````````````````````` example
+foo__bar__
+.
+<p>foo__bar__</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+5__6__78
+.
+<p>5__6__78</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+пристаням__стремятся__
+.
+<p>пристаням__стремятся__</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+__foo, __bar__, baz__
+.
+<p><strong>foo, <strong>bar</strong>, baz</strong></p>
+````````````````````````````````
+
+
+This is strong emphasis, even though the opening delimiter is
+both left- and right-flanking, because it is preceded by
+punctuation:
+
+```````````````````````````````` example
+foo-__(bar)__
+.
+<p>foo-<strong>(bar)</strong></p>
+````````````````````````````````
+
+
+
+Rule 7:
+
+This is not strong emphasis, because the closing delimiter is preceded
+by whitespace:
+
+```````````````````````````````` example
+**foo bar **
+.
+<p>**foo bar **</p>
+````````````````````````````````
+
+
+(Nor can it be interpreted as an emphasized `*foo bar *`, because of
+Rule 11.)
+
+This is not strong emphasis, because the second `**` is
+preceded by punctuation and followed by an alphanumeric:
+
+```````````````````````````````` example
+**(**foo)
+.
+<p>**(**foo)</p>
+````````````````````````````````
+
+
+The point of this restriction is more easily appreciated
+with these examples:
+
+```````````````````````````````` example
+*(**foo**)*
+.
+<p><em>(<strong>foo</strong>)</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+**Gomphocarpus (*Gomphocarpus physocarpus*, syn.
+*Asclepias physocarpa*)**
+.
+<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.
+<em>Asclepias physocarpa</em>)</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+**foo "*bar*" foo**
+.
+<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>
+````````````````````````````````
+
+
+Intraword emphasis:
+
+```````````````````````````````` example
+**foo**bar
+.
+<p><strong>foo</strong>bar</p>
+````````````````````````````````
+
+
+Rule 8:
+
+This is not strong emphasis, because the closing delimiter is
+preceded by whitespace:
+
+```````````````````````````````` example
+__foo bar __
+.
+<p>__foo bar __</p>
+````````````````````````````````
+
+
+This is not strong emphasis, because the second `__` is
+preceded by punctuation and followed by an alphanumeric:
+
+```````````````````````````````` example
+__(__foo)
+.
+<p>__(__foo)</p>
+````````````````````````````````
+
+
+The point of this restriction is more easily appreciated
+with this example:
+
+```````````````````````````````` example
+_(__foo__)_
+.
+<p><em>(<strong>foo</strong>)</em></p>
+````````````````````````````````
+
+
+Intraword strong emphasis is forbidden with `__`:
+
+```````````````````````````````` example
+__foo__bar
+.
+<p>__foo__bar</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+__пристаням__стремятся
+.
+<p>__пристаням__стремятся</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+__foo__bar__baz__
+.
+<p><strong>foo__bar__baz</strong></p>
+````````````````````````````````
+
+
+This is strong emphasis, even though the closing delimiter is
+both left- and right-flanking, because it is followed by
+punctuation:
+
+```````````````````````````````` example
+__(bar)__.
+.
+<p><strong>(bar)</strong>.</p>
+````````````````````````````````
+
+
+Rule 9:
+
+Any nonempty sequence of inline elements can be the contents of an
+emphasized span.
+
+```````````````````````````````` example
+*foo [bar](/url)*
+.
+<p><em>foo <a href="/url">bar</a></em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*foo
+bar*
+.
+<p><em>foo
+bar</em></p>
+````````````````````````````````
+
+
+In particular, emphasis and strong emphasis can be nested
+inside emphasis:
+
+```````````````````````````````` example
+_foo __bar__ baz_
+.
+<p><em>foo <strong>bar</strong> baz</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+_foo _bar_ baz_
+.
+<p><em>foo <em>bar</em> baz</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+__foo_ bar_
+.
+<p><em><em>foo</em> bar</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*foo *bar**
+.
+<p><em>foo <em>bar</em></em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*foo **bar** baz*
+.
+<p><em>foo <strong>bar</strong> baz</em></p>
+````````````````````````````````
+
+```````````````````````````````` example
+*foo**bar**baz*
+.
+<p><em>foo<strong>bar</strong>baz</em></p>
+````````````````````````````````
+
+Note that in the preceding case, the interpretation
+
+``` markdown
+<p><em>foo</em><em>bar<em></em>baz</em></p>
+```
+
+
+is precluded by the condition that a delimiter that
+can both open and close (like the `*` after `foo`)
+cannot form emphasis if the sum of the lengths of
+the delimiter runs containing the opening and
+closing delimiters is a multiple of 3 unless
+both lengths are multiples of 3.
+
+
+For the same reason, we don't get two consecutive
+emphasis sections in this example:
+
+```````````````````````````````` example
+*foo**bar*
+.
+<p><em>foo**bar</em></p>
+````````````````````````````````
+
+
+The same condition ensures that the following
+cases are all strong emphasis nested inside
+emphasis, even when the interior spaces are
+omitted:
+
+
+```````````````````````````````` example
+***foo** bar*
+.
+<p><em><strong>foo</strong> bar</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*foo **bar***
+.
+<p><em>foo <strong>bar</strong></em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*foo**bar***
+.
+<p><em>foo<strong>bar</strong></em></p>
+````````````````````````````````
+
+
+When the lengths of the interior closing and opening
+delimiter runs are *both* multiples of 3, though,
+they can match to create emphasis:
+
+```````````````````````````````` example
+foo***bar***baz
+.
+<p>foo<em><strong>bar</strong></em>baz</p>
+````````````````````````````````
+
+```````````````````````````````` example
+foo******bar*********baz
+.
+<p>foo<strong><strong><strong>bar</strong></strong></strong>***baz</p>
+````````````````````````````````
+
+
+Indefinite levels of nesting are possible:
+
+```````````````````````````````` example
+*foo **bar *baz* bim** bop*
+.
+<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*foo [*bar*](/url)*
+.
+<p><em>foo <a href="/url"><em>bar</em></a></em></p>
+````````````````````````````````
+
+
+There can be no empty emphasis or strong emphasis:
+
+```````````````````````````````` example
+** is not an empty emphasis
+.
+<p>** is not an empty emphasis</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+**** is not an empty strong emphasis
+.
+<p>**** is not an empty strong emphasis</p>
+````````````````````````````````
+
+
+
+Rule 10:
+
+Any nonempty sequence of inline elements can be the contents of an
+strongly emphasized span.
+
+```````````````````````````````` example
+**foo [bar](/url)**
+.
+<p><strong>foo <a href="/url">bar</a></strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+**foo
+bar**
+.
+<p><strong>foo
+bar</strong></p>
+````````````````````````````````
+
+
+In particular, emphasis and strong emphasis can be nested
+inside strong emphasis:
+
+```````````````````````````````` example
+__foo _bar_ baz__
+.
+<p><strong>foo <em>bar</em> baz</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+__foo __bar__ baz__
+.
+<p><strong>foo <strong>bar</strong> baz</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+____foo__ bar__
+.
+<p><strong><strong>foo</strong> bar</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+**foo **bar****
+.
+<p><strong>foo <strong>bar</strong></strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+**foo *bar* baz**
+.
+<p><strong>foo <em>bar</em> baz</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+**foo*bar*baz**
+.
+<p><strong>foo<em>bar</em>baz</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+***foo* bar**
+.
+<p><strong><em>foo</em> bar</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+**foo *bar***
+.
+<p><strong>foo <em>bar</em></strong></p>
+````````````````````````````````
+
+
+Indefinite levels of nesting are possible:
+
+```````````````````````````````` example
+**foo *bar **baz**
+bim* bop**
+.
+<p><strong>foo <em>bar <strong>baz</strong>
+bim</em> bop</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+**foo [*bar*](/url)**
+.
+<p><strong>foo <a href="/url"><em>bar</em></a></strong></p>
+````````````````````````````````
+
+
+There can be no empty emphasis or strong emphasis:
+
+```````````````````````````````` example
+__ is not an empty emphasis
+.
+<p>__ is not an empty emphasis</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+____ is not an empty strong emphasis
+.
+<p>____ is not an empty strong emphasis</p>
+````````````````````````````````
+
+
+
+Rule 11:
+
+```````````````````````````````` example
+foo ***
+.
+<p>foo ***</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo *\**
+.
+<p>foo <em>*</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo *_*
+.
+<p>foo <em>_</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo *****
+.
+<p>foo *****</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo **\***
+.
+<p>foo <strong>*</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo **_**
+.
+<p>foo <strong>_</strong></p>
+````````````````````````````````
+
+
+Note that when delimiters do not match evenly, Rule 11 determines
+that the excess literal `*` characters will appear outside of the
+emphasis, rather than inside it:
+
+```````````````````````````````` example
+**foo*
+.
+<p>*<em>foo</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*foo**
+.
+<p><em>foo</em>*</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+***foo**
+.
+<p>*<strong>foo</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+****foo*
+.
+<p>***<em>foo</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+**foo***
+.
+<p><strong>foo</strong>*</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*foo****
+.
+<p><em>foo</em>***</p>
+````````````````````````````````
+
+
+
+Rule 12:
+
+```````````````````````````````` example
+foo ___
+.
+<p>foo ___</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo _\__
+.
+<p>foo <em>_</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo _*_
+.
+<p>foo <em>*</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo _____
+.
+<p>foo _____</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo __\___
+.
+<p>foo <strong>_</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo __*__
+.
+<p>foo <strong>*</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+__foo_
+.
+<p>_<em>foo</em></p>
+````````````````````````````````
+
+
+Note that when delimiters do not match evenly, Rule 12 determines
+that the excess literal `_` characters will appear outside of the
+emphasis, rather than inside it:
+
+```````````````````````````````` example
+_foo__
+.
+<p><em>foo</em>_</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+___foo__
+.
+<p>_<strong>foo</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+____foo_
+.
+<p>___<em>foo</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+__foo___
+.
+<p><strong>foo</strong>_</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+_foo____
+.
+<p><em>foo</em>___</p>
+````````````````````````````````
+
+
+Rule 13 implies that if you want emphasis nested directly inside
+emphasis, you must use different delimiters:
+
+```````````````````````````````` example
+**foo**
+.
+<p><strong>foo</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*_foo_*
+.
+<p><em><em>foo</em></em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+__foo__
+.
+<p><strong>foo</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+_*foo*_
+.
+<p><em><em>foo</em></em></p>
+````````````````````````````````
+
+
+However, strong emphasis within strong emphasis is possible without
+switching delimiters:
+
+```````````````````````````````` example
+****foo****
+.
+<p><strong><strong>foo</strong></strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+____foo____
+.
+<p><strong><strong>foo</strong></strong></p>
+````````````````````````````````
+
+
+
+Rule 13 can be applied to arbitrarily long sequences of
+delimiters:
+
+```````````````````````````````` example
+******foo******
+.
+<p><strong><strong><strong>foo</strong></strong></strong></p>
+````````````````````````````````
+
+
+Rule 14:
+
+```````````````````````````````` example
+***foo***
+.
+<p><em><strong>foo</strong></em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+_____foo_____
+.
+<p><em><strong><strong>foo</strong></strong></em></p>
+````````````````````````````````
+
+
+Rule 15:
+
+```````````````````````````````` example
+*foo _bar* baz_
+.
+<p><em>foo _bar</em> baz_</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*foo __bar *baz bim__ bam*
+.
+<p><em>foo <strong>bar *baz bim</strong> bam</em></p>
+````````````````````````````````
+
+
+Rule 16:
+
+```````````````````````````````` example
+**foo **bar baz**
+.
+<p>**foo <strong>bar baz</strong></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*foo *bar baz*
+.
+<p>*foo <em>bar baz</em></p>
+````````````````````````````````
+
+
+Rule 17:
+
+```````````````````````````````` example
+*[bar*](/url)
+.
+<p>*<a href="/url">bar*</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+_foo [bar_](/url)
+.
+<p>_foo <a href="/url">bar_</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*<img src="foo" title="*"/>
+.
+<p>*<img src="foo" title="*"/></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+**<a href="**">
+.
+<p>**<a href="**"></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+__<a href="__">
+.
+<p>__<a href="__"></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*a `*`*
+.
+<p><em>a <code>*</code></em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+_a `_`_
+.
+<p><em>a <code>_</code></em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+**a<http://foo.bar/?q=**>
+.
+<p>**a<a href="http://foo.bar/?q=**">http://foo.bar/?q=**</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+__a<http://foo.bar/?q=__>
+.
+<p>__a<a href="http://foo.bar/?q=__">http://foo.bar/?q=__</a></p>
+````````````````````````````````
+
+
+<div class="extension">
+
+## Strikethrough (extension)
+
+GFM enables the `strikethrough` extension, where an additional emphasis type is
+available.
+
+Strikethrough text is any text wrapped in two tildes (`~`).
+
+```````````````````````````````` example strikethrough
+~~Hi~~ Hello, world!
+.
+<p><del>Hi</del> Hello, world!</p>
+````````````````````````````````
+
+As with regular emphasis delimiters, a new paragraph will cause strikethrough
+parsing to cease:
+
+```````````````````````````````` example strikethrough
+This ~~has a
+
+new paragraph~~.
+.
+<p>This ~~has a</p>
+<p>new paragraph~~.</p>
+````````````````````````````````
+
+</div>
+
+## Links
+
+A link contains [link text] (the visible text), a [link destination]
+(the URI that is the link destination), and optionally a [link title].
+There are two basic kinds of links in Markdown.  In [inline links] the
+destination and title are given immediately after the link text.  In
+[reference links] the destination and title are defined elsewhere in
+the document.
+
+A [link text](@) consists of a sequence of zero or more
+inline elements enclosed by square brackets (`[` and `]`).  The
+following rules apply:
+
+- Links may not contain other links, at any level of nesting. If
+  multiple otherwise valid link definitions appear nested inside each
+  other, the inner-most definition is used.
+
+- Brackets are allowed in the [link text] only if (a) they
+  are backslash-escaped or (b) they appear as a matched pair of brackets,
+  with an open bracket `[`, a sequence of zero or more inlines, and
+  a close bracket `]`.
+
+- Backtick [code spans], [autolinks], and raw [HTML tags] bind more tightly
+  than the brackets in link text.  Thus, for example,
+  `` [foo`]` `` could not be a link text, since the second `]`
+  is part of a code span.
+
+- The brackets in link text bind more tightly than markers for
+  [emphasis and strong emphasis]. Thus, for example, `*[foo*](url)` is a link.
+
+A [link destination](@) consists of either
+
+- a sequence of zero or more characters between an opening `<` and a
+  closing `>` that contains no line breaks or unescaped
+  `<` or `>` characters, or
+
+- a nonempty sequence of characters that does not start with
+  `<`, does not include ASCII space or control characters, and
+  includes parentheses only if (a) they are backslash-escaped or
+  (b) they are part of a balanced pair of unescaped parentheses.
+  (Implementations may impose limits on parentheses nesting to
+  avoid performance issues, but at least three levels of nesting
+  should be supported.)
+
+A [link title](@)  consists of either
+
+- a sequence of zero or more characters between straight double-quote
+  characters (`"`), including a `"` character only if it is
+  backslash-escaped, or
+
+- a sequence of zero or more characters between straight single-quote
+  characters (`'`), including a `'` character only if it is
+  backslash-escaped, or
+
+- a sequence of zero or more characters between matching parentheses
+  (`(...)`), including a `(` or `)` character only if it is
+  backslash-escaped.
+
+Although [link titles] may span multiple lines, they may not contain
+a [blank line].
+
+An [inline link](@) consists of a [link text] followed immediately
+by a left parenthesis `(`, optional [whitespace], an optional
+[link destination], an optional [link title] separated from the link
+destination by [whitespace], optional [whitespace], and a right
+parenthesis `)`. The link's text consists of the inlines contained
+in the [link text] (excluding the enclosing square brackets).
+The link's URI consists of the link destination, excluding enclosing
+`<...>` if present, with backslash-escapes in effect as described
+above.  The link's title consists of the link title, excluding its
+enclosing delimiters, with backslash-escapes in effect as described
+above.
+
+Here is a simple inline link:
+
+```````````````````````````````` example
+[link](/uri "title")
+.
+<p><a href="/uri" title="title">link</a></p>
+````````````````````````````````
+
+
+The title may be omitted:
+
+```````````````````````````````` example
+[link](/uri)
+.
+<p><a href="/uri">link</a></p>
+````````````````````````````````
+
+
+Both the title and the destination may be omitted:
+
+```````````````````````````````` example
+[link]()
+.
+<p><a href="">link</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[link](<>)
+.
+<p><a href="">link</a></p>
+````````````````````````````````
+
+The destination can only contain spaces if it is
+enclosed in pointy brackets:
+
+```````````````````````````````` example
+[link](/my uri)
+.
+<p>[link](/my uri)</p>
+````````````````````````````````
+
+```````````````````````````````` example
+[link](</my uri>)
+.
+<p><a href="/my%20uri">link</a></p>
+````````````````````````````````
+
+The destination cannot contain line breaks,
+even if enclosed in pointy brackets:
+
+```````````````````````````````` example
+[link](foo
+bar)
+.
+<p>[link](foo
+bar)</p>
+````````````````````````````````
+
+```````````````````````````````` example
+[link](<foo
+bar>)
+.
+<p>[link](<foo
+bar>)</p>
+````````````````````````````````
+
+The destination can contain `)` if it is enclosed
+in pointy brackets:
+
+```````````````````````````````` example
+[a](<b)c>)
+.
+<p><a href="b)c">a</a></p>
+````````````````````````````````
+
+Pointy brackets that enclose links must be unescaped:
+
+```````````````````````````````` example
+[link](<foo\>)
+.
+<p>[link](&lt;foo&gt;)</p>
+````````````````````````````````
+
+These are not links, because the opening pointy bracket
+is not matched properly:
+
+```````````````````````````````` example
+[a](<b)c
+[a](<b)c>
+[a](<b>c)
+.
+<p>[a](&lt;b)c
+[a](&lt;b)c&gt;
+[a](<b>c)</p>
+````````````````````````````````
+
+Parentheses inside the link destination may be escaped:
+
+```````````````````````````````` example
+[link](\(foo\))
+.
+<p><a href="(foo)">link</a></p>
+````````````````````````````````
+
+Any number of parentheses are allowed without escaping, as long as they are
+balanced:
+
+```````````````````````````````` example
+[link](foo(and(bar)))
+.
+<p><a href="foo(and(bar))">link</a></p>
+````````````````````````````````
+
+However, if you have unbalanced parentheses, you need to escape or use the
+`<...>` form:
+
+```````````````````````````````` example
+[link](foo\(and\(bar\))
+.
+<p><a href="foo(and(bar)">link</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[link](<foo(and(bar)>)
+.
+<p><a href="foo(and(bar)">link</a></p>
+````````````````````````````````
+
+
+Parentheses and other symbols can also be escaped, as usual
+in Markdown:
+
+```````````````````````````````` example
+[link](foo\)\:)
+.
+<p><a href="foo):">link</a></p>
+````````````````````````````````
+
+
+A link can contain fragment identifiers and queries:
+
+```````````````````````````````` example
+[link](#fragment)
+
+[link](http://example.com#fragment)
+
+[link](http://example.com?foo=3#frag)
+.
+<p><a href="#fragment">link</a></p>
+<p><a href="http://example.com#fragment">link</a></p>
+<p><a href="http://example.com?foo=3#frag">link</a></p>
+````````````````````````````````
+
+
+Note that a backslash before a non-escapable character is
+just a backslash:
+
+```````````````````````````````` example
+[link](foo\bar)
+.
+<p><a href="foo%5Cbar">link</a></p>
+````````````````````````````````
+
+
+URL-escaping should be left alone inside the destination, as all
+URL-escaped characters are also valid URL characters. Entity and
+numerical character references in the destination will be parsed
+into the corresponding Unicode code points, as usual.  These may
+be optionally URL-escaped when written as HTML, but this spec
+does not enforce any particular policy for rendering URLs in
+HTML or other formats.  Renderers may make different decisions
+about how to escape or normalize URLs in the output.
+
+```````````````````````````````` example
+[link](foo%20b&auml;)
+.
+<p><a href="foo%20b%C3%A4">link</a></p>
+````````````````````````````````
+
+
+Note that, because titles can often be parsed as destinations,
+if you try to omit the destination and keep the title, you'll
+get unexpected results:
+
+```````````````````````````````` example
+[link]("title")
+.
+<p><a href="%22title%22">link</a></p>
+````````````````````````````````
+
+
+Titles may be in single quotes, double quotes, or parentheses:
+
+```````````````````````````````` example
+[link](/url "title")
+[link](/url 'title')
+[link](/url (title))
+.
+<p><a href="/url" title="title">link</a>
+<a href="/url" title="title">link</a>
+<a href="/url" title="title">link</a></p>
+````````````````````````````````
+
+
+Backslash escapes and entity and numeric character references
+may be used in titles:
+
+```````````````````````````````` example
+[link](/url "title \"&quot;")
+.
+<p><a href="/url" title="title &quot;&quot;">link</a></p>
+````````````````````````````````
+
+
+Titles must be separated from the link using a [whitespace].
+Other [Unicode whitespace] like non-breaking space doesn't work.
+
+```````````````````````````````` example
+[link](/url "title")
+.
+<p><a href="/url%C2%A0%22title%22">link</a></p>
+````````````````````````````````
+
+
+Nested balanced quotes are not allowed without escaping:
+
+```````````````````````````````` example
+[link](/url "title "and" title")
+.
+<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>
+````````````````````````````````
+
+
+But it is easy to work around this by using a different quote type:
+
+```````````````````````````````` example
+[link](/url 'title "and" title')
+.
+<p><a href="/url" title="title &quot;and&quot; title">link</a></p>
+````````````````````````````````
+
+
+(Note:  `Markdown.pl` did allow double quotes inside a double-quoted
+title, and its test suite included a test demonstrating this.
+But it is hard to see a good rationale for the extra complexity this
+brings, since there are already many ways---backslash escaping,
+entity and numeric character references, or using a different
+quote type for the enclosing title---to write titles containing
+double quotes.  `Markdown.pl`'s handling of titles has a number
+of other strange features.  For example, it allows single-quoted
+titles in inline links, but not reference links.  And, in
+reference links but not inline links, it allows a title to begin
+with `"` and end with `)`.  `Markdown.pl` 1.0.1 even allows
+titles with no closing quotation mark, though 1.0.2b8 does not.
+It seems preferable to adopt a simple, rational rule that works
+the same way in inline links and link reference definitions.)
+
+[Whitespace] is allowed around the destination and title:
+
+```````````````````````````````` example
+[link](   /uri
+  "title"  )
+.
+<p><a href="/uri" title="title">link</a></p>
+````````````````````````````````
+
+
+But it is not allowed between the link text and the
+following parenthesis:
+
+```````````````````````````````` example
+[link] (/uri)
+.
+<p>[link] (/uri)</p>
+````````````````````````````````
+
+
+The link text may contain balanced brackets, but not unbalanced ones,
+unless they are escaped:
+
+```````````````````````````````` example
+[link [foo [bar]]](/uri)
+.
+<p><a href="/uri">link [foo [bar]]</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[link] bar](/uri)
+.
+<p>[link] bar](/uri)</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[link [bar](/uri)
+.
+<p>[link <a href="/uri">bar</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[link \[bar](/uri)
+.
+<p><a href="/uri">link [bar</a></p>
+````````````````````````````````
+
+
+The link text may contain inline content:
+
+```````````````````````````````` example
+[link *foo **bar** `#`*](/uri)
+.
+<p><a href="/uri">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[![moon](moon.jpg)](/uri)
+.
+<p><a href="/uri"><img src="moon.jpg" alt="moon" /></a></p>
+````````````````````````````````
+
+
+However, links may not contain other links, at any level of nesting.
+
+```````````````````````````````` example
+[foo [bar](/uri)](/uri)
+.
+<p>[foo <a href="/uri">bar</a>](/uri)</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo *[bar [baz](/uri)](/uri)*](/uri)
+.
+<p>[foo <em>[bar <a href="/uri">baz</a>](/uri)</em>](/uri)</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+![[[foo](uri1)](uri2)](uri3)
+.
+<p><img src="uri3" alt="[foo](uri2)" /></p>
+````````````````````````````````
+
+
+These cases illustrate the precedence of link text grouping over
+emphasis grouping:
+
+```````````````````````````````` example
+*[foo*](/uri)
+.
+<p>*<a href="/uri">foo*</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo *bar](baz*)
+.
+<p><a href="baz*">foo *bar</a></p>
+````````````````````````````````
+
+
+Note that brackets that *aren't* part of links do not take
+precedence:
+
+```````````````````````````````` example
+*foo [bar* baz]
+.
+<p><em>foo [bar</em> baz]</p>
+````````````````````````````````
+
+
+These cases illustrate the precedence of HTML tags, code spans,
+and autolinks over link grouping:
+
+```````````````````````````````` example
+[foo <bar attr="](baz)">
+.
+<p>[foo <bar attr="](baz)"></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo`](/uri)`
+.
+<p>[foo<code>](/uri)</code></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo<http://example.com/?search=](uri)>
+.
+<p>[foo<a href="http://example.com/?search=%5D(uri)">http://example.com/?search=](uri)</a></p>
+````````````````````````````````
+
+
+There are three kinds of [reference link](@)s:
+[full](#full-reference-link), [collapsed](#collapsed-reference-link),
+and [shortcut](#shortcut-reference-link).
+
+A [full reference link](@)
+consists of a [link text] immediately followed by a [link label]
+that [matches] a [link reference definition] elsewhere in the document.
+
+A [link label](@)  begins with a left bracket (`[`) and ends
+with the first right bracket (`]`) that is not backslash-escaped.
+Between these brackets there must be at least one [non-whitespace character].
+Unescaped square bracket characters are not allowed inside the
+opening and closing square brackets of [link labels].  A link
+label can have at most 999 characters inside the square
+brackets.
+
+One label [matches](@)
+another just in case their normalized forms are equal.  To normalize a
+label, strip off the opening and closing brackets,
+perform the *Unicode case fold*, strip leading and trailing
+[whitespace] and collapse consecutive internal
+[whitespace] to a single space.  If there are multiple
+matching reference link definitions, the one that comes first in the
+document is used.  (It is desirable in such cases to emit a warning.)
+
+The contents of the first link label are parsed as inlines, which are
+used as the link's text.  The link's URI and title are provided by the
+matching [link reference definition].
+
+Here is a simple example:
+
+```````````````````````````````` example
+[foo][bar]
+
+[bar]: /url "title"
+.
+<p><a href="/url" title="title">foo</a></p>
+````````````````````````````````
+
+
+The rules for the [link text] are the same as with
+[inline links].  Thus:
+
+The link text may contain balanced brackets, but not unbalanced ones,
+unless they are escaped:
+
+```````````````````````````````` example
+[link [foo [bar]]][ref]
+
+[ref]: /uri
+.
+<p><a href="/uri">link [foo [bar]]</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[link \[bar][ref]
+
+[ref]: /uri
+.
+<p><a href="/uri">link [bar</a></p>
+````````````````````````````````
+
+
+The link text may contain inline content:
+
+```````````````````````````````` example
+[link *foo **bar** `#`*][ref]
+
+[ref]: /uri
+.
+<p><a href="/uri">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[![moon](moon.jpg)][ref]
+
+[ref]: /uri
+.
+<p><a href="/uri"><img src="moon.jpg" alt="moon" /></a></p>
+````````````````````````````````
+
+
+However, links may not contain other links, at any level of nesting.
+
+```````````````````````````````` example
+[foo [bar](/uri)][ref]
+
+[ref]: /uri
+.
+<p>[foo <a href="/uri">bar</a>]<a href="/uri">ref</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo *bar [baz][ref]*][ref]
+
+[ref]: /uri
+.
+<p>[foo <em>bar <a href="/uri">baz</a></em>]<a href="/uri">ref</a></p>
+````````````````````````````````
+
+
+(In the examples above, we have two [shortcut reference links]
+instead of one [full reference link].)
+
+The following cases illustrate the precedence of link text grouping over
+emphasis grouping:
+
+```````````````````````````````` example
+*[foo*][ref]
+
+[ref]: /uri
+.
+<p>*<a href="/uri">foo*</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo *bar][ref]
+
+[ref]: /uri
+.
+<p><a href="/uri">foo *bar</a></p>
+````````````````````````````````
+
+
+These cases illustrate the precedence of HTML tags, code spans,
+and autolinks over link grouping:
+
+```````````````````````````````` example
+[foo <bar attr="][ref]">
+
+[ref]: /uri
+.
+<p>[foo <bar attr="][ref]"></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo`][ref]`
+
+[ref]: /uri
+.
+<p>[foo<code>][ref]</code></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo<http://example.com/?search=][ref]>
+
+[ref]: /uri
+.
+<p>[foo<a href="http://example.com/?search=%5D%5Bref%5D">http://example.com/?search=][ref]</a></p>
+````````````````````````````````
+
+
+Matching is case-insensitive:
+
+```````````````````````````````` example
+[foo][BaR]
+
+[bar]: /url "title"
+.
+<p><a href="/url" title="title">foo</a></p>
+````````````````````````````````
+
+
+Unicode case fold is used:
+
+```````````````````````````````` example
+[Толпой][Толпой] is a Russian word.
+
+[ТОЛПОЙ]: /url
+.
+<p><a href="/url">Толпой</a> is a Russian word.</p>
+````````````````````````````````
+
+
+Consecutive internal [whitespace] is treated as one space for
+purposes of determining matching:
+
+```````````````````````````````` example
+[Foo
+  bar]: /url
+
+[Baz][Foo bar]
+.
+<p><a href="/url">Baz</a></p>
+````````````````````````````````
+
+
+No [whitespace] is allowed between the [link text] and the
+[link label]:
+
+```````````````````````````````` example
+[foo] [bar]
+
+[bar]: /url "title"
+.
+<p>[foo] <a href="/url" title="title">bar</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo]
+[bar]
+
+[bar]: /url "title"
+.
+<p>[foo]
+<a href="/url" title="title">bar</a></p>
+````````````````````````````````
+
+
+This is a departure from John Gruber's original Markdown syntax
+description, which explicitly allows whitespace between the link
+text and the link label.  It brings reference links in line with
+[inline links], which (according to both original Markdown and
+this spec) cannot have whitespace after the link text.  More
+importantly, it prevents inadvertent capture of consecutive
+[shortcut reference links]. If whitespace is allowed between the
+link text and the link label, then in the following we will have
+a single reference link, not two shortcut reference links, as
+intended:
+
+``` markdown
+[foo]
+[bar]
+
+[foo]: /url1
+[bar]: /url2
+```
+
+(Note that [shortcut reference links] were introduced by Gruber
+himself in a beta version of `Markdown.pl`, but never included
+in the official syntax description.  Without shortcut reference
+links, it is harmless to allow space between the link text and
+link label; but once shortcut references are introduced, it is
+too dangerous to allow this, as it frequently leads to
+unintended results.)
+
+When there are multiple matching [link reference definitions],
+the first is used:
+
+```````````````````````````````` example
+[foo]: /url1
+
+[foo]: /url2
+
+[bar][foo]
+.
+<p><a href="/url1">bar</a></p>
+````````````````````````````````
+
+
+Note that matching is performed on normalized strings, not parsed
+inline content.  So the following does not match, even though the
+labels define equivalent inline content:
+
+```````````````````````````````` example
+[bar][foo\!]
+
+[foo!]: /url
+.
+<p>[bar][foo!]</p>
+````````````````````````````````
+
+
+[Link labels] cannot contain brackets, unless they are
+backslash-escaped:
+
+```````````````````````````````` example
+[foo][ref[]
+
+[ref[]: /uri
+.
+<p>[foo][ref[]</p>
+<p>[ref[]: /uri</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo][ref[bar]]
+
+[ref[bar]]: /uri
+.
+<p>[foo][ref[bar]]</p>
+<p>[ref[bar]]: /uri</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[[[foo]]]
+
+[[[foo]]]: /url
+.
+<p>[[[foo]]]</p>
+<p>[[[foo]]]: /url</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[foo][ref\[]
+
+[ref\[]: /uri
+.
+<p><a href="/uri">foo</a></p>
+````````````````````````````````
+
+
+Note that in this example `]` is not backslash-escaped:
+
+```````````````````````````````` example
+[bar\\]: /uri
+
+[bar\\]
+.
+<p><a href="/uri">bar\</a></p>
+````````````````````````````````
+
+
+A [link label] must contain at least one [non-whitespace character]:
+
+```````````````````````````````` example
+[]
+
+[]: /uri
+.
+<p>[]</p>
+<p>[]: /uri</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[
+ ]
+
+[
+ ]: /uri
+.
+<p>[
+]</p>
+<p>[
+]: /uri</p>
+````````````````````````````````
+
+
+A [collapsed reference link](@)
+consists of a [link label] that [matches] a
+[link reference definition] elsewhere in the
+document, followed by the string `[]`.
+The contents of the first link label are parsed as inlines,
+which are used as the link's text.  The link's URI and title are
+provided by the matching reference link definition.  Thus,
+`[foo][]` is equivalent to `[foo][foo]`.
+
+```````````````````````````````` example
+[foo][]
+
+[foo]: /url "title"
+.
+<p><a href="/url" title="title">foo</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[*foo* bar][]
+
+[*foo* bar]: /url "title"
+.
+<p><a href="/url" title="title"><em>foo</em> bar</a></p>
+````````````````````````````````
+
+
+The link labels are case-insensitive:
+
+```````````````````````````````` example
+[Foo][]
+
+[foo]: /url "title"
+.
+<p><a href="/url" title="title">Foo</a></p>
+````````````````````````````````
+
+
+
+As with full reference links, [whitespace] is not
+allowed between the two sets of brackets:
+
+```````````````````````````````` example
+[foo] 
+[]
+
+[foo]: /url "title"
+.
+<p><a href="/url" title="title">foo</a>
+[]</p>
+````````````````````````````````
+
+
+A [shortcut reference link](@)
+consists of a [link label] that [matches] a
+[link reference definition] elsewhere in the
+document and is not followed by `[]` or a link label.
+The contents of the first link label are parsed as inlines,
+which are used as the link's text.  The link's URI and title
+are provided by the matching link reference definition.
+Thus, `[foo]` is equivalent to `[foo][]`.
+
+```````````````````````````````` example
+[foo]
+
+[foo]: /url "title"
+.
+<p><a href="/url" title="title">foo</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[*foo* bar]
+
+[*foo* bar]: /url "title"
+.
+<p><a href="/url" title="title"><em>foo</em> bar</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[[*foo* bar]]
+
+[*foo* bar]: /url "title"
+.
+<p>[<a href="/url" title="title"><em>foo</em> bar</a>]</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+[[bar [foo]
+
+[foo]: /url
+.
+<p>[[bar <a href="/url">foo</a></p>
+````````````````````````````````
+
+
+The link labels are case-insensitive:
+
+```````````````````````````````` example
+[Foo]
+
+[foo]: /url "title"
+.
+<p><a href="/url" title="title">Foo</a></p>
+````````````````````````````````
+
+
+A space after the link text should be preserved:
+
+```````````````````````````````` example
+[foo] bar
+
+[foo]: /url
+.
+<p><a href="/url">foo</a> bar</p>
+````````````````````````````````
+
+
+If you just want bracketed text, you can backslash-escape the
+opening bracket to avoid links:
+
+```````````````````````````````` example
+\[foo]
+
+[foo]: /url "title"
+.
+<p>[foo]</p>
+````````````````````````````````
+
+
+Note that this is a link, because a link label ends with the first
+following closing bracket:
+
+```````````````````````````````` example
+[foo*]: /url
+
+*[foo*]
+.
+<p>*<a href="/url">foo*</a></p>
+````````````````````````````````
+
+
+Full and compact references take precedence over shortcut
+references:
+
+```````````````````````````````` example
+[foo][bar]
+
+[foo]: /url1
+[bar]: /url2
+.
+<p><a href="/url2">foo</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[foo][]
+
+[foo]: /url1
+.
+<p><a href="/url1">foo</a></p>
+````````````````````````````````
+
+Inline links also take precedence:
+
+```````````````````````````````` example
+[foo]()
+
+[foo]: /url1
+.
+<p><a href="">foo</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[foo](not a link)
+
+[foo]: /url1
+.
+<p><a href="/url1">foo</a>(not a link)</p>
+````````````````````````````````
+
+In the following case `[bar][baz]` is parsed as a reference,
+`[foo]` as normal text:
+
+```````````````````````````````` example
+[foo][bar][baz]
+
+[baz]: /url
+.
+<p>[foo]<a href="/url">bar</a></p>
+````````````````````````````````
+
+
+Here, though, `[foo][bar]` is parsed as a reference, since
+`[bar]` is defined:
+
+```````````````````````````````` example
+[foo][bar][baz]
+
+[baz]: /url1
+[bar]: /url2
+.
+<p><a href="/url2">foo</a><a href="/url1">baz</a></p>
+````````````````````````````````
+
+
+Here `[foo]` is not parsed as a shortcut reference, because it
+is followed by a link label (even though `[bar]` is not defined):
+
+```````````````````````````````` example
+[foo][bar][baz]
+
+[baz]: /url1
+[foo]: /url2
+.
+<p>[foo]<a href="/url1">bar</a></p>
+````````````````````````````````
+
+
+
+## Images
+
+Syntax for images is like the syntax for links, with one
+difference. Instead of [link text], we have an
+[image description](@).  The rules for this are the
+same as for [link text], except that (a) an
+image description starts with `![` rather than `[`, and
+(b) an image description may contain links.
+An image description has inline elements
+as its contents.  When an image is rendered to HTML,
+this is standardly used as the image's `alt` attribute.
+
+```````````````````````````````` example
+![foo](/url "title")
+.
+<p><img src="/url" alt="foo" title="title" /></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+![foo *bar*]
+
+[foo *bar*]: train.jpg "train & tracks"
+.
+<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+![foo ![bar](/url)](/url2)
+.
+<p><img src="/url2" alt="foo bar" /></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+![foo [bar](/url)](/url2)
+.
+<p><img src="/url2" alt="foo bar" /></p>
+````````````````````````````````
+
+
+Though this spec is concerned with parsing, not rendering, it is
+recommended that in rendering to HTML, only the plain string content
+of the [image description] be used.  Note that in
+the above example, the alt attribute's value is `foo bar`, not `foo
+[bar](/url)` or `foo <a href="/url">bar</a>`.  Only the plain string
+content is rendered, without formatting.
+
+```````````````````````````````` example
+![foo *bar*][]
+
+[foo *bar*]: train.jpg "train & tracks"
+.
+<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+![foo *bar*][foobar]
+
+[FOOBAR]: train.jpg "train & tracks"
+.
+<p><img src="train.jpg" alt="foo bar" title="train &amp; tracks" /></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+![foo](train.jpg)
+.
+<p><img src="train.jpg" alt="foo" /></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+My ![foo bar](/path/to/train.jpg  "title"   )
+.
+<p>My <img src="/path/to/train.jpg" alt="foo bar" title="title" /></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+![foo](<url>)
+.
+<p><img src="url" alt="foo" /></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+![](/url)
+.
+<p><img src="/url" alt="" /></p>
+````````````````````````````````
+
+
+Reference-style:
+
+```````````````````````````````` example
+![foo][bar]
+
+[bar]: /url
+.
+<p><img src="/url" alt="foo" /></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+![foo][bar]
+
+[BAR]: /url
+.
+<p><img src="/url" alt="foo" /></p>
+````````````````````````````````
+
+
+Collapsed:
+
+```````````````````````````````` example
+![foo][]
+
+[foo]: /url "title"
+.
+<p><img src="/url" alt="foo" title="title" /></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+![*foo* bar][]
+
+[*foo* bar]: /url "title"
+.
+<p><img src="/url" alt="foo bar" title="title" /></p>
+````````````````````````````````
+
+
+The labels are case-insensitive:
+
+```````````````````````````````` example
+![Foo][]
+
+[foo]: /url "title"
+.
+<p><img src="/url" alt="Foo" title="title" /></p>
+````````````````````````````````
+
+
+As with reference links, [whitespace] is not allowed
+between the two sets of brackets:
+
+```````````````````````````````` example
+![foo] 
+[]
+
+[foo]: /url "title"
+.
+<p><img src="/url" alt="foo" title="title" />
+[]</p>
+````````````````````````````````
+
+
+Shortcut:
+
+```````````````````````````````` example
+![foo]
+
+[foo]: /url "title"
+.
+<p><img src="/url" alt="foo" title="title" /></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+![*foo* bar]
+
+[*foo* bar]: /url "title"
+.
+<p><img src="/url" alt="foo bar" title="title" /></p>
+````````````````````````````````
+
+
+Note that link labels cannot contain unescaped brackets:
+
+```````````````````````````````` example
+![[foo]]
+
+[[foo]]: /url "title"
+.
+<p>![[foo]]</p>
+<p>[[foo]]: /url &quot;title&quot;</p>
+````````````````````````````````
+
+
+The link labels are case-insensitive:
+
+```````````````````````````````` example
+![Foo]
+
+[foo]: /url "title"
+.
+<p><img src="/url" alt="Foo" title="title" /></p>
+````````````````````````````````
+
+
+If you just want a literal `!` followed by bracketed text, you can
+backslash-escape the opening `[`:
+
+```````````````````````````````` example
+!\[foo]
+
+[foo]: /url "title"
+.
+<p>![foo]</p>
+````````````````````````````````
+
+
+If you want a link after a literal `!`, backslash-escape the
+`!`:
+
+```````````````````````````````` example
+\![foo]
+
+[foo]: /url "title"
+.
+<p>!<a href="/url" title="title">foo</a></p>
+````````````````````````````````
+
+
+## Autolinks
+
+[Autolink](@)s are absolute URIs and email addresses inside
+`<` and `>`. They are parsed as links, with the URL or email address
+as the link label.
+
+A [URI autolink](@) consists of `<`, followed by an
+[absolute URI] followed by `>`.  It is parsed as
+a link to the URI, with the URI as the link's label.
+
+An [absolute URI](@),
+for these purposes, consists of a [scheme] followed by a colon (`:`)
+followed by zero or more characters other than ASCII
+[whitespace] and control characters, `<`, and `>`.  If
+the URI includes these characters, they must be percent-encoded
+(e.g. `%20` for a space).
+
+For purposes of this spec, a [scheme](@) is any sequence
+of 2--32 characters beginning with an ASCII letter and followed
+by any combination of ASCII letters, digits, or the symbols plus
+("+"), period ("."), or hyphen ("-").
+
+Here are some valid autolinks:
+
+```````````````````````````````` example
+<http://foo.bar.baz>
+.
+<p><a href="http://foo.bar.baz">http://foo.bar.baz</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<http://foo.bar.baz/test?q=hello&id=22&boolean>
+.
+<p><a href="http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">http://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<irc://foo.bar:2233/baz>
+.
+<p><a href="irc://foo.bar:2233/baz">irc://foo.bar:2233/baz</a></p>
+````````````````````````````````
+
+
+Uppercase is also fine:
+
+```````````````````````````````` example
+<MAILTO:FOO@BAR.BAZ>
+.
+<p><a href="MAILTO:FOO@BAR.BAZ">MAILTO:FOO@BAR.BAZ</a></p>
+````````````````````````````````
+
+
+Note that many strings that count as [absolute URIs] for
+purposes of this spec are not valid URIs, because their
+schemes are not registered or because of other problems
+with their syntax:
+
+```````````````````````````````` example
+<a+b+c:d>
+.
+<p><a href="a+b+c:d">a+b+c:d</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<made-up-scheme://foo,bar>
+.
+<p><a href="made-up-scheme://foo,bar">made-up-scheme://foo,bar</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<http://../>
+.
+<p><a href="http://../">http://../</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<localhost:5001/foo>
+.
+<p><a href="localhost:5001/foo">localhost:5001/foo</a></p>
+````````````````````````````````
+
+
+Spaces are not allowed in autolinks:
+
+```````````````````````````````` example
+<http://foo.bar/baz bim>
+.
+<p>&lt;http://foo.bar/baz bim&gt;</p>
+````````````````````````````````
+
+
+Backslash-escapes do not work inside autolinks:
+
+```````````````````````````````` example
+<http://example.com/\[\>
+.
+<p><a href="http://example.com/%5C%5B%5C">http://example.com/\[\</a></p>
+````````````````````````````````
+
+
+An [email autolink](@)
+consists of `<`, followed by an [email address],
+followed by `>`.  The link's label is the email address,
+and the URL is `mailto:` followed by the email address.
+
+An [email address](@),
+for these purposes, is anything that matches
+the [non-normative regex from the HTML5
+spec](https://html.spec.whatwg.org/multipage/forms.html#e-mail-state-(type=email)):
+
+    /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?
+    (?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+
+Examples of email autolinks:
+
+```````````````````````````````` example
+<foo@bar.example.com>
+.
+<p><a href="mailto:foo@bar.example.com">foo@bar.example.com</a></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<foo+special@Bar.baz-bar0.com>
+.
+<p><a href="mailto:foo+special@Bar.baz-bar0.com">foo+special@Bar.baz-bar0.com</a></p>
+````````````````````````````````
+
+
+Backslash-escapes do not work inside email autolinks:
+
+```````````````````````````````` example
+<foo\+@bar.example.com>
+.
+<p>&lt;foo+@bar.example.com&gt;</p>
+````````````````````````````````
+
+
+These are not autolinks:
+
+```````````````````````````````` example
+<>
+.
+<p>&lt;&gt;</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+< http://foo.bar >
+.
+<p>&lt; http://foo.bar &gt;</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<m:abc>
+.
+<p>&lt;m:abc&gt;</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<foo.bar.baz>
+.
+<p>&lt;foo.bar.baz&gt;</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+http://example.com
+.
+<p>http://example.com</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo@bar.example.com
+.
+<p>foo@bar.example.com</p>
+````````````````````````````````
+
+<div class="extension">
+
+## Autolinks (extension)
+
+GFM enables the `autolink` extension, where autolinks will be recognised in a
+greater number of conditions.
+
+[Autolink]s can also be constructed without requiring the use of `<` and to `>`
+to delimit them, although they will be recognized under a smaller set of
+circumstances.  All such recognized autolinks can only come at the beginning of
+a line, after whitespace, or any of the delimiting characters `*`, `_`, `~`,
+and `(`.
+
+An [extended www autolink](@) will be recognized
+when the text `www.` is found followed by a [valid domain].
+A [valid domain](@) consists of segments
+of alphanumeric characters, underscores (`_`) and hyphens (`-`)
+separated by periods (`.`).
+There must be at least one period,
+and no underscores may be present in the last two segments of the domain.
+
+The scheme `http` will be inserted automatically:
+
+```````````````````````````````` example autolink
+www.commonmark.org
+.
+<p><a href="http://www.commonmark.org">www.commonmark.org</a></p>
+````````````````````````````````
+
+After a [valid domain], zero or more non-space non-`<` characters may follow:
+
+```````````````````````````````` example autolink
+Visit www.commonmark.org/help for more information.
+.
+<p>Visit <a href="http://www.commonmark.org/help">www.commonmark.org/help</a> for more information.</p>
+````````````````````````````````
+
+We then apply [extended autolink path validation](@) as follows:
+
+Trailing punctuation (specifically, `?`, `!`, `.`, `,`, `:`, `*`, `_`, and `~`)
+will not be considered part of the autolink, though they may be included in the
+interior of the link:
+
+```````````````````````````````` example autolink
+Visit www.commonmark.org.
+
+Visit www.commonmark.org/a.b.
+.
+<p>Visit <a href="http://www.commonmark.org">www.commonmark.org</a>.</p>
+<p>Visit <a href="http://www.commonmark.org/a.b">www.commonmark.org/a.b</a>.</p>
+````````````````````````````````
+
+When an autolink ends in `)`, we scan the entire autolink for the total number
+of parentheses.  If there is a greater number of closing parentheses than
+opening ones, we don't consider the unmatched trailing parentheses part of the
+autolink, in order to facilitate including an autolink inside a parenthesis:
+
+```````````````````````````````` example autolink
+www.google.com/search?q=Markup+(business)
+
+www.google.com/search?q=Markup+(business)))
+
+(www.google.com/search?q=Markup+(business))
+
+(www.google.com/search?q=Markup+(business)
+.
+<p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>
+<p><a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>))</p>
+<p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a>)</p>
+<p>(<a href="http://www.google.com/search?q=Markup+(business)">www.google.com/search?q=Markup+(business)</a></p>
+````````````````````````````````
+
+This check is only done when the link ends in a closing parentheses `)`, so if
+the only parentheses are in the interior of the autolink, no special rules are
+applied:
+
+```````````````````````````````` example autolink
+www.google.com/search?q=(business))+ok
+.
+<p><a href="http://www.google.com/search?q=(business))+ok">www.google.com/search?q=(business))+ok</a></p>
+````````````````````````````````
+
+If an autolink ends in a semicolon (`;`), we check to see if it appears to
+resemble an [entity reference][entity references]; if the preceding text is `&`
+followed by one or more alphanumeric characters.  If so, it is excluded from
+the autolink:
+
+```````````````````````````````` example autolink
+www.google.com/search?q=commonmark&hl=en
+
+www.google.com/search?q=commonmark&hl;
+.
+<p><a href="http://www.google.com/search?q=commonmark&amp;hl=en">www.google.com/search?q=commonmark&amp;hl=en</a></p>
+<p><a href="http://www.google.com/search?q=commonmark">www.google.com/search?q=commonmark</a>&amp;hl;</p>
+````````````````````````````````
+
+`<` immediately ends an autolink.
+
+```````````````````````````````` example autolink
+www.commonmark.org/he<lp
+.
+<p><a href="http://www.commonmark.org/he">www.commonmark.org/he</a>&lt;lp</p>
+````````````````````````````````
+
+An [extended url autolink](@) will be recognised when one of the schemes
+`http://`, `https://`, or `ftp://`, followed by a [valid domain], then zero or
+more non-space non-`<` characters according to
+[extended autolink path validation]:
+
+```````````````````````````````` example autolink
+http://commonmark.org
+
+(Visit https://encrypted.google.com/search?q=Markup+(business))
+
+Anonymous FTP is available at ftp://foo.bar.baz.
+.
+<p><a href="http://commonmark.org">http://commonmark.org</a></p>
+<p>(Visit <a href="https://encrypted.google.com/search?q=Markup+(business)">https://encrypted.google.com/search?q=Markup+(business)</a>)</p>
+<p>Anonymous FTP is available at <a href="ftp://foo.bar.baz">ftp://foo.bar.baz</a>.</p>
+````````````````````````````````
+
+
+An [extended email autolink](@) will be recognised when an email address is
+recognised within any text node.  Email addresses are recognised according to
+the following rules:
+
+* One ore more characters which are alphanumeric, or `.`, `-`, `_`, or `+`.
+* An `@` symbol.
+* One or more characters which are alphanumeric, or `-` or `_`,
+  separated by periods (`.`).
+  There must be at least one period.
+  The last character must not be one of `-` or `_`.
+
+The scheme `mailto:` will automatically be added to the generated link:
+
+```````````````````````````````` example autolink
+foo@bar.baz
+.
+<p><a href="mailto:foo@bar.baz">foo@bar.baz</a></p>
+````````````````````````````````
+
+`+` can occur before the `@`, but not after.
+
+```````````````````````````````` example autolink
+hello@mail+xyz.example isn't valid, but hello+xyz@mail.example is.
+.
+<p>hello@mail+xyz.example isn't valid, but <a href="mailto:hello+xyz@mail.example">hello+xyz@mail.example</a> is.</p>
+````````````````````````````````
+
+`.`, `-`, and `_` can occur on both sides of the `@`, but only `.` may occur at
+the end of the email address, in which case it will not be considered part of
+the address:
+
+```````````````````````````````` example autolink
+a.b-c_d@a.b
+
+a.b-c_d@a.b.
+
+a.b-c_d@a.b-
+
+a.b-c_d@a.b_
+.
+<p><a href="mailto:a.b-c_d@a.b">a.b-c_d@a.b</a></p>
+<p><a href="mailto:a.b-c_d@a.b">a.b-c_d@a.b</a>.</p>
+<p>a.b-c_d@a.b-</p>
+<p>a.b-c_d@a.b_</p>
+````````````````````````````````
+
+</div>
+
+## Raw HTML
+
+Text between `<` and `>` that looks like an HTML tag is parsed as a
+raw HTML tag and will be rendered in HTML without escaping.
+Tag and attribute names are not limited to current HTML tags,
+so custom tags (and even, say, DocBook tags) may be used.
+
+Here is the grammar for tags:
+
+A [tag name](@) consists of an ASCII letter
+followed by zero or more ASCII letters, digits, or
+hyphens (`-`).
+
+An [attribute](@) consists of [whitespace],
+an [attribute name], and an optional
+[attribute value specification].
+
+An [attribute name](@)
+consists of an ASCII letter, `_`, or `:`, followed by zero or more ASCII
+letters, digits, `_`, `.`, `:`, or `-`.  (Note:  This is the XML
+specification restricted to ASCII.  HTML5 is laxer.)
+
+An [attribute value specification](@)
+consists of optional [whitespace],
+a `=` character, optional [whitespace], and an [attribute
+value].
+
+An [attribute value](@)
+consists of an [unquoted attribute value],
+a [single-quoted attribute value], or a [double-quoted attribute value].
+
+An [unquoted attribute value](@)
+is a nonempty string of characters not
+including [whitespace], `"`, `'`, `=`, `<`, `>`, or `` ` ``.
+
+A [single-quoted attribute value](@)
+consists of `'`, zero or more
+characters not including `'`, and a final `'`.
+
+A [double-quoted attribute value](@)
+consists of `"`, zero or more
+characters not including `"`, and a final `"`.
+
+An [open tag](@) consists of a `<` character, a [tag name],
+zero or more [attributes], optional [whitespace], an optional `/`
+character, and a `>` character.
+
+A [closing tag](@) consists of the string `</`, a
+[tag name], optional [whitespace], and the character `>`.
+
+An [HTML comment](@) consists of `<!--` + *text* + `-->`,
+where *text* does not start with `>` or `->`, does not end with `-`,
+and does not contain `--`.  (See the
+[HTML5 spec](http://www.w3.org/TR/html5/syntax.html#comments).)
+
+A [processing instruction](@)
+consists of the string `<?`, a string
+of characters not including the string `?>`, and the string
+`?>`.
+
+A [declaration](@) consists of the
+string `<!`, a name consisting of one or more uppercase ASCII letters,
+[whitespace], a string of characters not including the
+character `>`, and the character `>`.
+
+A [CDATA section](@) consists of
+the string `<![CDATA[`, a string of characters not including the string
+`]]>`, and the string `]]>`.
+
+An [HTML tag](@) consists of an [open tag], a [closing tag],
+an [HTML comment], a [processing instruction], a [declaration],
+or a [CDATA section].
+
+Here are some simple open tags:
+
+```````````````````````````````` example
+<a><bab><c2c>
+.
+<p><a><bab><c2c></p>
+````````````````````````````````
+
+
+Empty elements:
+
+```````````````````````````````` example
+<a/><b2/>
+.
+<p><a/><b2/></p>
+````````````````````````````````
+
+
+[Whitespace] is allowed:
+
+```````````````````````````````` example
+<a  /><b2
+data="foo" >
+.
+<p><a  /><b2
+data="foo" ></p>
+````````````````````````````````
+
+
+With attributes:
+
+```````````````````````````````` example
+<a foo="bar" bam = 'baz <em>"</em>'
+_boolean zoop:33=zoop:33 />
+.
+<p><a foo="bar" bam = 'baz <em>"</em>'
+_boolean zoop:33=zoop:33 /></p>
+````````````````````````````````
+
+
+Custom tag names can be used:
+
+```````````````````````````````` example
+Foo <responsive-image src="foo.jpg" />
+.
+<p>Foo <responsive-image src="foo.jpg" /></p>
+````````````````````````````````
+
+
+Illegal tag names, not parsed as HTML:
+
+```````````````````````````````` example
+<33> <__>
+.
+<p>&lt;33&gt; &lt;__&gt;</p>
+````````````````````````````````
+
+
+Illegal attribute names:
+
+```````````````````````````````` example
+<a h*#ref="hi">
+.
+<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>
+````````````````````````````````
+
+
+Illegal attribute values:
+
+```````````````````````````````` example
+<a href="hi'> <a href=hi'>
+.
+<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>
+````````````````````````````````
+
+
+Illegal [whitespace]:
+
+```````````````````````````````` example
+< a><
+foo><bar/ >
+<foo bar=baz
+bim!bop />
+.
+<p>&lt; a&gt;&lt;
+foo&gt;&lt;bar/ &gt;
+&lt;foo bar=baz
+bim!bop /&gt;</p>
+````````````````````````````````
+
+
+Missing [whitespace]:
+
+```````````````````````````````` example
+<a href='bar'title=title>
+.
+<p>&lt;a href='bar'title=title&gt;</p>
+````````````````````````````````
+
+
+Closing tags:
+
+```````````````````````````````` example
+</a></foo >
+.
+<p></a></foo ></p>
+````````````````````````````````
+
+
+Illegal attributes in closing tag:
+
+```````````````````````````````` example
+</a href="foo">
+.
+<p>&lt;/a href=&quot;foo&quot;&gt;</p>
+````````````````````````````````
+
+
+Comments:
+
+```````````````````````````````` example
+foo <!-- this is a
+comment - with hyphen -->
+.
+<p>foo <!-- this is a
+comment - with hyphen --></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo <!-- not a comment -- two hyphens -->
+.
+<p>foo &lt;!-- not a comment -- two hyphens --&gt;</p>
+````````````````````````````````
+
+
+Not comments:
+
+```````````````````````````````` example
+foo <!--> foo -->
+
+foo <!-- foo--->
+.
+<p>foo &lt;!--&gt; foo --&gt;</p>
+<p>foo &lt;!-- foo---&gt;</p>
+````````````````````````````````
+
+
+Processing instructions:
+
+```````````````````````````````` example
+foo <?php echo $a; ?>
+.
+<p>foo <?php echo $a; ?></p>
+````````````````````````````````
+
+
+Declarations:
+
+```````````````````````````````` example
+foo <!ELEMENT br EMPTY>
+.
+<p>foo <!ELEMENT br EMPTY></p>
+````````````````````````````````
+
+
+CDATA sections:
+
+```````````````````````````````` example
+foo <![CDATA[>&<]]>
+.
+<p>foo <![CDATA[>&<]]></p>
+````````````````````````````````
+
+
+Entity and numeric character references are preserved in HTML
+attributes:
+
+```````````````````````````````` example
+foo <a href="&ouml;">
+.
+<p>foo <a href="&ouml;"></p>
+````````````````````````````````
+
+
+Backslash escapes do not work in HTML attributes:
+
+```````````````````````````````` example
+foo <a href="\*">
+.
+<p>foo <a href="\*"></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<a href="\"">
+.
+<p>&lt;a href=&quot;&quot;&quot;&gt;</p>
+````````````````````````````````
+
+
+<div class="extension">
+
+## Disallowed Raw HTML (extension)
+
+GFM enables the `tagfilter` extension, where the following HTML tags will be
+filtered when rendering HTML output:
+
+* `<title>`
+* `<textarea>`
+* `<style>`
+* `<xmp>`
+* `<iframe>`
+* `<noembed>`
+* `<noframes>`
+* `<script>`
+* `<plaintext>`
+
+Filtering is done by replacing the leading `<` with the entity `&lt;`.  These
+tags are chosen in particular as they change how HTML is interpreted in a way
+unique to them (i.e. nested HTML is interpreted differently), and this is
+usually undesireable in the context of other rendered Markdown content.
+
+All other HTML tags are left untouched.
+
+```````````````````````````````` example tagfilter
+<strong> <title> <style> <em>
+
+<blockquote>
+  <xmp> is disallowed.  <XMP> is also disallowed.
+</blockquote>
+.
+<p><strong> &lt;title> &lt;style> <em></p>
+<blockquote>
+  &lt;xmp> is disallowed.  &lt;XMP> is also disallowed.
+</blockquote>
+````````````````````````````````
+
+</div>
+
+## Hard line breaks
+
+A line break (not in a code span or HTML tag) that is preceded
+by two or more spaces and does not occur at the end of a block
+is parsed as a [hard line break](@) (rendered
+in HTML as a `<br />` tag):
+
+```````````````````````````````` example
+foo  
+baz
+.
+<p>foo<br />
+baz</p>
+````````````````````````````````
+
+
+For a more visible alternative, a backslash before the
+[line ending] may be used instead of two spaces:
+
+```````````````````````````````` example
+foo\
+baz
+.
+<p>foo<br />
+baz</p>
+````````````````````````````````
+
+
+More than two spaces can be used:
+
+```````````````````````````````` example
+foo       
+baz
+.
+<p>foo<br />
+baz</p>
+````````````````````````````````
+
+
+Leading spaces at the beginning of the next line are ignored:
+
+```````````````````````````````` example
+foo  
+     bar
+.
+<p>foo<br />
+bar</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo\
+     bar
+.
+<p>foo<br />
+bar</p>
+````````````````````````````````
+
+
+Line breaks can occur inside emphasis, links, and other constructs
+that allow inline content:
+
+```````````````````````````````` example
+*foo  
+bar*
+.
+<p><em>foo<br />
+bar</em></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+*foo\
+bar*
+.
+<p><em>foo<br />
+bar</em></p>
+````````````````````````````````
+
+
+Line breaks do not occur inside code spans
+
+```````````````````````````````` example
+`code  
+span`
+.
+<p><code>code   span</code></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+`code\
+span`
+.
+<p><code>code\ span</code></p>
+````````````````````````````````
+
+
+or HTML tags:
+
+```````````````````````````````` example
+<a href="foo  
+bar">
+.
+<p><a href="foo  
+bar"></p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+<a href="foo\
+bar">
+.
+<p><a href="foo\
+bar"></p>
+````````````````````````````````
+
+
+Hard line breaks are for separating inline content within a block.
+Neither syntax for hard line breaks works at the end of a paragraph or
+other block element:
+
+```````````````````````````````` example
+foo\
+.
+<p>foo\</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+foo  
+.
+<p>foo</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+### foo\
+.
+<h3>foo\</h3>
+````````````````````````````````
+
+
+```````````````````````````````` example
+### foo  
+.
+<h3>foo</h3>
+````````````````````````````````
+
+
+## Soft line breaks
+
+A regular line break (not in a code span or HTML tag) that is not
+preceded by two or more spaces or a backslash is parsed as a
+[softbreak](@).  (A softbreak may be rendered in HTML either as a
+[line ending] or as a space. The result will be the same in
+browsers. In the examples here, a [line ending] will be used.)
+
+```````````````````````````````` example
+foo
+baz
+.
+<p>foo
+baz</p>
+````````````````````````````````
+
+
+Spaces at the end of the line and beginning of the next line are
+removed:
+
+```````````````````````````````` example
+foo 
+ baz
+.
+<p>foo
+baz</p>
+````````````````````````````````
+
+
+A conforming parser may render a soft line break in HTML either as a
+line break or as a space.
+
+A renderer may also provide an option to render soft line breaks
+as hard line breaks.
+
+## Textual content
+
+Any characters not given an interpretation by the above rules will
+be parsed as plain textual content.
+
+```````````````````````````````` example
+hello $.;'there
+.
+<p>hello $.;'there</p>
+````````````````````````````````
+
+
+```````````````````````````````` example
+Foo χρῆν
+.
+<p>Foo χρῆν</p>
+````````````````````````````````
+
+
+Internal spaces are preserved verbatim:
+
+```````````````````````````````` example
+Multiple     spaces
+.
+<p>Multiple     spaces</p>
+````````````````````````````````
+
+
+<!-- END TESTS -->
+
+# Appendix: A parsing strategy
+
+In this appendix we describe some features of the parsing strategy
+used in the CommonMark reference implementations.
+
+## Overview
+
+Parsing has two phases:
+
+1. In the first phase, lines of input are consumed and the block
+structure of the document---its division into paragraphs, block quotes,
+list items, and so on---is constructed.  Text is assigned to these
+blocks but not parsed. Link reference definitions are parsed and a
+map of links is constructed.
+
+2. In the second phase, the raw text contents of paragraphs and headings
+are parsed into sequences of Markdown inline elements (strings,
+code spans, links, emphasis, and so on), using the map of link
+references constructed in phase 1.
+
+At each point in processing, the document is represented as a tree of
+**blocks**.  The root of the tree is a `document` block.  The `document`
+may have any number of other blocks as **children**.  These children
+may, in turn, have other blocks as children.  The last child of a block
+is normally considered **open**, meaning that subsequent lines of input
+can alter its contents.  (Blocks that are not open are **closed**.)
+Here, for example, is a possible document tree, with the open blocks
+marked by arrows:
+
+``` tree
+-> document
+  -> block_quote
+       paragraph
+         "Lorem ipsum dolor\nsit amet."
+    -> list (type=bullet tight=true bullet_char=-)
+         list_item
+           paragraph
+             "Qui *quodsi iracundia*"
+      -> list_item
+        -> paragraph
+             "aliquando id"
+```
+
+## Phase 1: block structure
+
+Each line that is processed has an effect on this tree.  The line is
+analyzed and, depending on its contents, the document may be altered
+in one or more of the following ways:
+
+1. One or more open blocks may be closed.
+2. One or more new blocks may be created as children of the
+   last open block.
+3. Text may be added to the last (deepest) open block remaining
+   on the tree.
+
+Once a line has been incorporated into the tree in this way,
+it can be discarded, so input can be read in a stream.
+
+For each line, we follow this procedure:
+
+1. First we iterate through the open blocks, starting with the
+root document, and descending through last children down to the last
+open block.  Each block imposes a condition that the line must satisfy
+if the block is to remain open.  For example, a block quote requires a
+`>` character.  A paragraph requires a non-blank line.
+In this phase we may match all or just some of the open
+blocks.  But we cannot close unmatched blocks yet, because we may have a
+[lazy continuation line].
+
+2.  Next, after consuming the continuation markers for existing
+blocks, we look for new block starts (e.g. `>` for a block quote).
+If we encounter a new block start, we close any blocks unmatched
+in step 1 before creating the new block as a child of the last
+matched block.
+
+3.  Finally, we look at the remainder of the line (after block
+markers like `>`, list markers, and indentation have been consumed).
+This is text that can be incorporated into the last open
+block (a paragraph, code block, heading, or raw HTML).
+
+Setext headings are formed when we see a line of a paragraph
+that is a [setext heading underline].
+
+Reference link definitions are detected when a paragraph is closed;
+the accumulated text lines are parsed to see if they begin with
+one or more reference link definitions.  Any remainder becomes a
+normal paragraph.
+
+We can see how this works by considering how the tree above is
+generated by four lines of Markdown:
+
+``` markdown
+> Lorem ipsum dolor
+sit amet.
+> - Qui *quodsi iracundia*
+> - aliquando id
+```
+
+At the outset, our document model is just
+
+``` tree
+-> document
+```
+
+The first line of our text,
+
+``` markdown
+> Lorem ipsum dolor
+```
+
+causes a `block_quote` block to be created as a child of our
+open `document` block, and a `paragraph` block as a child of
+the `block_quote`.  Then the text is added to the last open
+block, the `paragraph`:
+
+``` tree
+-> document
+  -> block_quote
+    -> paragraph
+         "Lorem ipsum dolor"
+```
+
+The next line,
+
+``` markdown
+sit amet.
+```
+
+is a "lazy continuation" of the open `paragraph`, so it gets added
+to the paragraph's text:
+
+``` tree
+-> document
+  -> block_quote
+    -> paragraph
+         "Lorem ipsum dolor\nsit amet."
+```
+
+The third line,
+
+``` markdown
+> - Qui *quodsi iracundia*
+```
+
+causes the `paragraph` block to be closed, and a new `list` block
+opened as a child of the `block_quote`.  A `list_item` is also
+added as a child of the `list`, and a `paragraph` as a child of
+the `list_item`.  The text is then added to the new `paragraph`:
+
+``` tree
+-> document
+  -> block_quote
+       paragraph
+         "Lorem ipsum dolor\nsit amet."
+    -> list (type=bullet tight=true bullet_char=-)
+      -> list_item
+        -> paragraph
+             "Qui *quodsi iracundia*"
+```
+
+The fourth line,
+
+``` markdown
+> - aliquando id
+```
+
+causes the `list_item` (and its child the `paragraph`) to be closed,
+and a new `list_item` opened up as child of the `list`.  A `paragraph`
+is added as a child of the new `list_item`, to contain the text.
+We thus obtain the final tree:
+
+``` tree
+-> document
+  -> block_quote
+       paragraph
+         "Lorem ipsum dolor\nsit amet."
+    -> list (type=bullet tight=true bullet_char=-)
+         list_item
+           paragraph
+             "Qui *quodsi iracundia*"
+      -> list_item
+        -> paragraph
+             "aliquando id"
+```
+
+## Phase 2: inline structure
+
+Once all of the input has been parsed, all open blocks are closed.
+
+We then "walk the tree," visiting every node, and parse raw
+string contents of paragraphs and headings as inlines.  At this
+point we have seen all the link reference definitions, so we can
+resolve reference links as we go.
+
+``` tree
+document
+  block_quote
+    paragraph
+      str "Lorem ipsum dolor"
+      softbreak
+      str "sit amet."
+    list (type=bullet tight=true bullet_char=-)
+      list_item
+        paragraph
+          str "Qui "
+          emph
+            str "quodsi iracundia"
+      list_item
+        paragraph
+          str "aliquando id"
+```
+
+Notice how the [line ending] in the first paragraph has
+been parsed as a `softbreak`, and the asterisks in the first list item
+have become an `emph`.
+
+### An algorithm for parsing nested emphasis and links
+
+By far the trickiest part of inline parsing is handling emphasis,
+strong emphasis, links, and images.  This is done using the following
+algorithm.
+
+When we're parsing inlines and we hit either
+
+- a run of `*` or `_` characters, or
+- a `[` or `![`
+
+we insert a text node with these symbols as its literal content, and we
+add a pointer to this text node to the [delimiter stack](@).
+
+The [delimiter stack] is a doubly linked list.  Each
+element contains a pointer to a text node, plus information about
+
+- the type of delimiter (`[`, `![`, `*`, `_`)
+- the number of delimiters,
+- whether the delimiter is "active" (all are active to start), and
+- whether the delimiter is a potential opener, a potential closer,
+  or both (which depends on what sort of characters precede
+  and follow the delimiters).
+
+When we hit a `]` character, we call the *look for link or image*
+procedure (see below).
+
+When we hit the end of the input, we call the *process emphasis*
+procedure (see below), with `stack_bottom` = NULL.
+
+#### *look for link or image*
+
+Starting at the top of the delimiter stack, we look backwards
+through the stack for an opening `[` or `![` delimiter.
+
+- If we don't find one, we return a literal text node `]`.
+
+- If we do find one, but it's not *active*, we remove the inactive
+  delimiter from the stack, and return a literal text node `]`.
+
+- If we find one and it's active, then we parse ahead to see if
+  we have an inline link/image, reference link/image, compact reference
+  link/image, or shortcut reference link/image.
+
+  + If we don't, then we remove the opening delimiter from the
+    delimiter stack and return a literal text node `]`.
+
+  + If we do, then
+
+    * We return a link or image node whose children are the inlines
+      after the text node pointed to by the opening delimiter.
+
+    * We run *process emphasis* on these inlines, with the `[` opener
+      as `stack_bottom`.
+
+    * We remove the opening delimiter.
+
+    * If we have a link (and not an image), we also set all
+      `[` delimiters before the opening delimiter to *inactive*.  (This
+      will prevent us from getting links within links.)
+
+#### *process emphasis*
+
+Parameter `stack_bottom` sets a lower bound to how far we
+descend in the [delimiter stack].  If it is NULL, we can
+go all the way to the bottom.  Otherwise, we stop before
+visiting `stack_bottom`.
+
+Let `current_position` point to the element on the [delimiter stack]
+just above `stack_bottom` (or the first element if `stack_bottom`
+is NULL).
+
+We keep track of the `openers_bottom` for each delimiter
+type (`*`, `_`) and each length of the closing delimiter run
+(modulo 3).  Initialize this to `stack_bottom`.
+
+Then we repeat the following until we run out of potential
+closers:
+
+- Move `current_position` forward in the delimiter stack (if needed)
+  until we find the first potential closer with delimiter `*` or `_`.
+  (This will be the potential closer closest
+  to the beginning of the input -- the first one in parse order.)
+
+- Now, look back in the stack (staying above `stack_bottom` and
+  the `openers_bottom` for this delimiter type) for the
+  first matching potential opener ("matching" means same delimiter).
+
+- If one is found:
+
+  + Figure out whether we have emphasis or strong emphasis:
+    if both closer and opener spans have length >= 2, we have
+    strong, otherwise regular.
+
+  + Insert an emph or strong emph node accordingly, after
+    the text node corresponding to the opener.
+
+  + Remove any delimiters between the opener and closer from
+    the delimiter stack.
+
+  + Remove 1 (for regular emph) or 2 (for strong emph) delimiters
+    from the opening and closing text nodes.  If they become empty
+    as a result, remove them and remove the corresponding element
+    of the delimiter stack.  If the closing node is removed, reset
+    `current_position` to the next element in the stack.
+
+- If none is found:
+
+  + Set `openers_bottom` to the element before `current_position`.
+    (We know that there are no openers for this kind of closer up to and
+    including this point, so this puts a lower bound on future searches.)
+
+  + If the closer at `current_position` is not a potential opener,
+    remove it from the delimiter stack (since we know it can't
+    be a closer either).
+
+  + Advance `current_position` to the next element in the stack.
+
+After we're done, we remove all delimiters above `stack_bottom` from the
+delimiter stack.

--- a/test/test_basics.rb
+++ b/test/test_basics.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestBasics < Minitest::Test
+  def test_to_html
+    html = Commonmarker.to_html("Hi *there*")
+    assert_equal("<p>Hi <em>there</em></p>\n", html)
+  end
+
+  # basic test that just checks that default option is accepted & no errors are thrown
+  def test_to_html_accept_default_options
+    text = "Hello **world** -- how are _you_ today? I'm ~~fine~~, ~yourself~?"
+
+    html = Commonmarker.to_html(text, options: Commonmarker::Config::OPTS).rstrip
+    assert_equal("<p>Hello <strong>world</strong> -- how are <em>you</em> today? I'm <del>fine</del>, <del>yourself</del>?</p>", html)
+  end
+end

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestEncoding < Minitest::Test
+  # see http://git.io/vq4FR
+  def test_encoding
+    contents = fixtures_file("curly.md")
+    render = Commonmarker.to_html(contents, options: { parse: { smart: true } })
+
+    assert_equal("<p>This curly quote “makes commonmarker throw an exception”.</p>", render.rstrip)
+  end
+
+  def test_string_content_is_utf8
+    html = Commonmarker.to_html("Hi *there*")
+    assert_equal("<p>Hi <em>there</em></p>", html.rstrip)
+    assert_equal("UTF-8", html.encoding.name)
+  end
+end

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestExtensions < Minitest::Test
+  def setup
+    @markdown = fixtures_file("table.md")
+  end
+
+  def test_uses_specified_extensions
+    Commonmarker.to_html(@markdown, options: { extension: {} }).tap do |out|
+      assert_includes(out, "| a")
+      assert_includes(out, "| <strong>x</strong>")
+      assert_includes(out, "~~hi~~")
+    end
+
+    Commonmarker.to_html(@markdown, options: { extension: { table: true } }).tap do |out|
+      refute_includes(out, "| a")
+      ["<table>", "<tr>", "<th>", "a", "</th>", "<td>", "c", "</td>", "<strong>x</strong>"].each { |html| assert_includes(out, html) }
+      assert_includes(out, "~~hi~~")
+    end
+
+    Commonmarker.to_html(@markdown, options: { extension: { strikethrough: true } }).tap do |out|
+      assert_includes(out, "| a")
+      refute_includes(out, "~~hi~~")
+      assert_includes(out, "<del>hi</del>")
+    end
+  end
+
+  def test_bad_extension_specifications
+    assert_raises(TypeError) { Commonmarker.to_html(@markdown, options: "nope") }
+  end
+
+  def test_comments_are_kept_as_expected
+    options = { render: { unsafe_: true }, extension: { tagfilter: true } }
+    assert_equal("<!--hello--> <blah> &lt;xmp>\n",
+      Commonmarker.to_html("<!--hello--> <blah> <xmp>\n", options: options))
+  end
+end

--- a/test/test_footnotes.rb
+++ b/test/test_footnotes.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestFootnotes < Minitest::Test
+  def test_to_html
+    md = <<~MARKDOWN
+      # footnotes
+      Let's render some footnotes[^1]
+
+      [^1]: This is a footnote
+    MARKDOWN
+    expected = <<~HTML
+      <h1>footnotes</h1>
+      <p>Let's render some footnotes<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup></p>
+      <section class="footnotes">
+      <ol>
+      <li id="fn1">
+      <p>This is a footnote <a href="#fnref1" class="footnote-backref">↩</a></p>
+      </li>
+      </ol>
+      </section>
+    HTML
+
+    assert_equal(expected, Commonmarker.to_html(md, options: { extension: { footnotes: true } }))
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "commonmarker"
+require "minitest/autorun"
+require "minitest/pride"
+require "minitest/focus"
+
+include Commonmarker
+
+FIXTURES_DIR = File.join(File.dirname(__FILE__), "fixtures")
+
+def fixtures_file(file)
+  File.read(File.join(FIXTURES_DIR, file), encoding: "utf-8")
+end
+
+def make_bin(file, args = "")
+  %x(ruby bin/commonmarker #{File.join(FIXTURES_DIR, file)} #{args}).chomp
+end
+
+def load_spec_file(filename)
+  line_number = 0
+  start_line = 0
+  end_line = 0
+  example_number = 0
+  markdown_lines = []
+  html_lines = []
+  state = 0 # 0 regular text, 1 markdown example, 2 html output
+  headertext = ""
+  tests = []
+  extensions = []
+
+  header_re = Regexp.new("#+ ")
+  filepath = File.join(FIXTURES_DIR, "upstream", filename)
+
+  File.readlines(filepath, encoding: "utf-8").each do |line|
+    line_number += 1
+
+    l = line.strip
+    if l =~ /^`{32} example(.*)$/
+      state = 1
+      extensions = Regexp.last_match(1).split
+    elsif l == "`" * 32
+      state = 0
+      example_number += 1
+      end_line = line_number
+      tests << {
+        markdown: markdown_lines.join.tr("→", "\t"),
+        html: html_lines.join.tr("→", "\t").rstrip,
+        example: example_number,
+        start_line: start_line,
+        end_line: end_line,
+        section: headertext,
+        extensions: extensions.map(&:to_sym),
+      }
+      start_line = 0
+      markdown_lines = []
+      html_lines = []
+    elsif l == "."
+      state = 2
+    elsif state == 1
+      start_line = line_number - 1 if start_line.zero?
+      markdown_lines << line.to_s
+    elsif state == 2
+      html_lines << line.to_s
+    elsif state.zero? && header_re.match(line)
+      headertext = line.sub(header_re, "").strip
+    end
+  end
+
+  tests
+end

--- a/test/test_linebreaks.rb
+++ b/test/test_linebreaks.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestLinebreaks < Minitest::Test
+  def setup
+    @options = { parse: { hardbreaks: true } }
+  end
+
+  def test_hardbreak_no_spaces
+    html = Commonmarker.to_html("foo\nbaz", options: @options)
+    assert_equal("<p>foo<br />\nbaz</p>\n", html)
+  end
+
+  def test_hardbreak_with_spaces
+    html = Commonmarker.to_html("foo  \nbaz", options: @options)
+    assert_equal("<p>foo<br />\nbaz</p>\n", html)
+  end
+end

--- a/test/test_maliciousness.rb
+++ b/test/test_maliciousness.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestMaliciousness < Minitest::Test
+  def test_rendering_with_bad_type
+    assert_raises(TypeError) do
+      Commonmarker.to_html(nil)
+    end
+
+    assert_raises(TypeError) do
+      Commonmarker.to_html(123)
+    end
+
+    assert_raises(TypeError) do
+      Commonmarker.to_html([123])
+    end
+
+    assert_raises(TypeError) do
+      Commonmarker.to_html("foo \n baz", options: 123)
+    end
+
+    assert_raises(TypeError) do
+      Commonmarker.to_html("foo \n baz", options: :totes_fake)
+    end
+
+    assert_raises(TypeError) do
+      Commonmarker.to_html("foo \n baz", options: [])
+    end
+
+    assert_raises(TypeError) do
+      Commonmarker.to_html("foo \n baz", options: [23])
+    end
+
+    assert_raises(TypeError) do
+      Commonmarker.to_html("foo \n baz", options: nil)
+    end
+
+    assert_raises(TypeError) do
+      Commonmarker.to_html("foo \n baz", options: [:SMART, "totes_fake"])
+    end
+  end
+
+  def test_bad_options_value
+    err = assert_raises(TypeError) do
+      Commonmarker.to_html("foo \n baz", options: { parse: { smart: 111 } })
+    end
+    assert_equal("parse_options[:smart] must be a Boolean; got Integer", err.message)
+  end
+end

--- a/test/test_pathological_inputs.rb
+++ b/test/test_pathological_inputs.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "minitest/benchmark" if ENV["BENCH"]
+
+def markdown(str)
+  Commonmarker.to_html(str).to_html
+end
+
+class PathologicalInputsPerformanceTest < Minitest::Benchmark
+  # list of pairs consisting of input and a regex that must match the output.
+  pathological = {
+    "nested strong emph" =>
+                ["#{"*a **a " * 65_000}b#{" a** a*" * 65_000}",
+                 Regexp.compile("(<em>a <strong>a ){65_000}b( a</strong> a</em>){65_000}"),],
+    "many emph closers with no openers" =>
+                 [("a_ " * 65_000),
+                  Regexp.compile("(a[_] ){64999}a_"),],
+    "many emph openers with no closers" =>
+                 [("_a " * 65_000),
+                  Regexp.compile("(_a ){64999}_a"),],
+    "many link closers with no openers" =>
+                 [("a]" * 65_000),
+                  Regexp.compile('(a\]){65_000}'),],
+    "many link openers with no closers" =>
+                 [("[a" * 65_000),
+                  Regexp.compile('(\[a){65_000}'),],
+    "mismatched openers and closers" =>
+                 [("*a_ " * 50_000),
+                  Regexp.compile("([*]a[_] ){49999}[*]a_"),],
+    "link openers and emph closers" =>
+                 [("[ a_" * 50_000),
+                  Regexp.compile('(\[ a_){50000}'),],
+    "hard link/emph case" =>
+                 ["**x [a*b**c*](d)",
+                  Regexp.compile('\\*\\*x <a href=\'d\'>a<em>b</em><em>c</em></a>'),],
+    "nested brackets" =>
+                 ["#{"[" * 50_000}a#{"]" * 50_000}",
+                  Regexp.compile('\[{50000}a\]{50000}'),],
+    "nested block quotes" =>
+                 ["#{"> " * 50_000}a",
+                  Regexp.compile('(<blockquote>\n){50000}'),],
+    "U+0000 in input" =>
+                 ['abc\u0000de\u0000',
+                  Regexp.compile('abc\ufffd?de\ufffd?'),],
+  }
+
+  pathological.each_pair do |name, description|
+    define_method("test_#{name}") do
+      input, = description
+      assert markdown(input)
+    end
+  end
+
+  def test_bench_pathological_one
+    assert_performance_linear(0.99) do |n|
+      star = "*" * (n * 10)
+      markdown("#{star}#{star}hi#{star}#{star}")
+    end
+  end
+
+  def test_bench_pathological_two
+    assert_performance_linear(0.99) do |n|
+      c = "`t`t`t`t`t`t" * (n * 10)
+      markdown(c)
+    end
+  end
+
+  def test_bench_pathological_three
+    assert_performance_linear(0.99) do |n|
+      markdown(" [a]: #{"A" * n}\n\n#{"[a][]" * n}\n")
+    end
+  end
+
+  def test_bench_pathological_four
+    assert_performance_linear(0.5) do |n|
+      markdown("#{"[" * n}a#{"]" * n}")
+    end
+  end
+
+  def test_bench_pathological_five
+    assert_performance_linear(0.99) do |n|
+      markdown("#{"**a *a " * n}#{"a* a**" * n}")
+    end
+  end
+
+  def test_bench_unbound_recursion
+    assert_performance_linear(0.99) do |n|
+      markdown("#{"[" * n}foo#{"](bar)" * n}")
+    end
+  end
+end if ENV["BENCH"]

--- a/test/test_smartpunct.rb
+++ b/test/test_smartpunct.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SmartPunctTest < Minitest::Test
+  smart_punct = load_spec_file("smart_punct.txt")
+
+  smart_punct.each do |testcase|
+    opts = {
+      parse: {
+        smart: true,
+      },
+      render: {
+        hardbreaks: false,
+      },
+    }
+
+    define_method("test_smart_punct_example_#{testcase[:example]}") do
+      html = Commonmarker.to_html(testcase[:markdown], options: opts).strip
+
+      assert_equal testcase[:html], html, testcase[:markdown]
+    end
+  end
+
+  def test_smart_hardbreak_no_spaces_render_doc
+    markdown = "\"foo\"\nbaz"
+    result = "<p>“foo”<br />\nbaz</p>\n"
+    opts = {
+      parse: {
+        smart: true,
+      },
+      render: {
+        hardbreaks: true,
+      },
+    }
+    html = Commonmarker.to_html(markdown, options: opts)
+    assert_equal(result, html)
+  end
+end

--- a/test/test_spec.rb
+++ b/test/test_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "json"
+
+class TestSpec < Minitest::Test
+  spec = load_spec_file("spec.txt")
+
+  spec.each do |testcase|
+    define_method("test_to_html_example_#{testcase[:example]}") do
+      opts = {
+        render: {
+          unsafe_: true,
+        },
+        extension: testcase[:extensions].each_with_object({}) do |ext, hash|
+          hash[ext] = true
+        end,
+      }
+
+      options = Commonmarker::Config.merged_with_defaults(opts)
+      options[:extension].delete(:header_ids) # this interefers with the spec.txt extension-less capability
+      options[:extension][:tasklist] = true
+      actual = Commonmarker.to_html(testcase[:markdown], options: options).rstrip
+
+      assert_equal testcase[:html], actual, testcase[:markdown]
+    end
+  end
+end

--- a/test/test_tasklists.rb
+++ b/test/test_tasklists.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestTasklists < Minitest::Test
+  def test_to_html
+    text = <<-MD
+ - [x] Add task list
+ - [ ] Define task list
+    MD
+    html = Commonmarker.to_html(text, options: { extension: { tasklist: true } })
+    expected = <<~HTML
+      <ul>
+      <li><input type="checkbox" disabled="" checked="" /> Add task list</li>
+      <li><input type="checkbox" disabled="" /> Define task list</li>
+      </ul>
+    HTML
+
+    assert_equal(expected, html)
+  end
+end


### PR DESCRIPTION
Relying nearly entirely on strategies devised by Nokogiri and in https://github.com/flavorjones/ruby-c-extensions-explained#strategy-3-precompiled, this PR completes the migration to Rust by providing OS-native precompiled binaries for various platforms. 