### PR TITLE
Update to 0290gfm6

### DIFF
--- a/ext/commonmarker/cmark-gfm_version.h
+++ b/ext/commonmarker/cmark-gfm_version.h
@@ -1,7 +1,7 @@
 #ifndef CMARK_GFM_VERSION_H
 #define CMARK_GFM_VERSION_H
 
-#define CMARK_GFM_VERSION ((0 << 24) | (29 << 16) | (0 << 8) | 5)
-#define CMARK_GFM_VERSION_STRING "0.29.0.gfm.5"
+#define CMARK_GFM_VERSION ((0 << 24) | (29 << 16) | (0 << 8) | 6)
+#define CMARK_GFM_VERSION_STRING "0.29.0.gfm.6"
 
 #endif


### PR DESCRIPTION
Hi @gjtorikian,

This PR bumps cmark-gfm to the latest upstream and addresses https://github.com/github/cmark-gfm/security/advisories/GHSA-cgh3-p57x-9q7q

This would be a security release for commonmarker. 

Please let me know if there are any issues or concerns that we can help with.