### PR TITLE
always use rb_sys (don't use Ruby's emerging cargo tooling where available)

### DIFF
--- a/commonmarker.gemspec
+++ b/commonmarker.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
 
   spec.require_paths = ["lib"]
-  spec.extensions = ["ext/commonmarker/Cargo.toml"]
+  spec.extensions = ["ext/commonmarker/extconf.rb"]
 
   spec.metadata = {
     "allowed_push_host" => "https://rubygems.org",

--- a/ext/commonmarker/extconf.rb
+++ b/ext/commonmarker/extconf.rb
@@ -3,4 +3,4 @@ require "rb_sys/mkmf"
 
 require_relative "_util"
 
-create_rust_makefile("commonmarker")
+create_rust_makefile("commonmarker/commonmarker")

--- a/lib/commonmarker/version.rb
+++ b/lib/commonmarker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Commonmarker
-  VERSION = "1.0.0.pre5"
+  VERSION = "1.0.0.pre6"
 end


### PR DESCRIPTION
Per @ianks at https://github.com/gjtorikian/commonmarker/pull/212#issuecomment-1374866289, I try to avoid using Ruby's own Cargo builder here. Tested it myself with darwin-arm64 and linux-x86_64 on 3.1.2 and 3.2.0 as best I could, but CI might have more to say.