### PR TITLE
Change `unsafe_` to `unsafe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Note that there is a distinction in comrak for "parse" options and "render" opti
 | `hardbreaks`      | [Soft line breaks](http://spec.commonmark.org/0.27/#soft-line-breaks) translate into hard line breaks. | `true`  |
 | `github_pre_lang` | GitHub-style `<pre lang="xyz">` is used for fenced code blocks with info tags.                         | `true`  |
 | `width`           | The wrap column when outputting CommonMark.                                                            | `80`    |
-| `unsafe_`         | Allow rendering of raw HTML and potentially dangerous links.                                           | `false` |
+| `unsafe`          | Allow rendering of raw HTML and potentially dangerous links.                                           | `false` |
 | `escape`          | Escape raw HTML instead of clobbering it.                                                              | `false` |
 
 As well, there are several extensions which you can toggle in the same manner:
@@ -100,18 +100,18 @@ For more information on these options, see [the comrak documentation](https://gi
 ### Plugins
 
 In addition to the possibilities provided by generic CommonMark rendering, Commonmarker also supports plugins as a means of
-providing further niceties. 
+providing further niceties.
 
 #### Syntax Highlighter Plugin
 
-```ruby
+````ruby
 code = <<~CODE
   ```ruby
   def hello
   puts "hello"
   end
 CODE
-  
+
 puts Commonmarker.to_html(code, plugins: { syntax_highlighter: { theme: "InspiredGitHub" } })
 
 # <pre style="background-color:#ffffff;" lang="ruby"><code>
@@ -120,7 +120,7 @@ puts Commonmarker.to_html(code, plugins: { syntax_highlighter: { theme: "Inspire
 # </span><span style="font-weight:bold;color:#a71d5d;">end
 # </span>
 # </code></pre>
-```
+````
 
 To disable this plugin, pass `nil`:
 

--- a/ext/commonmarker/src/options.rs
+++ b/ext/commonmarker/src/options.rs
@@ -29,7 +29,7 @@ fn iterate_parse_options(comrak_options: &mut ComrakOptions, options_hash: RHash
 const RENDER_HARDBREAKS: &str = "hardbreaks";
 const RENDER_GITHUB_PRE_LANG: &str = "github_pre_lang";
 const RENDER_WIDTH: &str = "width";
-const RENDER_UNSAFE: &str = "unsafe_";
+const RENDER_UNSAFE: &str = "unsafe";
 const RENDER_ESCAPE: &str = "escape";
 
 fn iterate_render_options(comrak_options: &mut ComrakOptions, options_hash: RHash) {

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -13,7 +13,7 @@ module Commonmarker
         hardbreaks: true,
         github_pre_lang: true,
         width: 80,
-        unsafe_: false,
+        unsafe: false,
         escape: false,
       }.freeze,
       extension: {

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -33,7 +33,7 @@ class TestExtensions < Minitest::Test
   end
 
   def test_comments_are_kept_as_expected
-    options = { render: { unsafe_: true }, extension: { tagfilter: true } }
+    options = { render: { unsafe: true }, extension: { tagfilter: true } }
 
     assert_equal(
       "<!--hello--> <blah> &lt;xmp>\n",
@@ -43,7 +43,7 @@ class TestExtensions < Minitest::Test
 
   def test_definition_lists
     markdown = <<~MARKDOWN
-      ~strikethrogh disabled to ensure options accepted~
+      ~strikethrough disabled to ensure options accepted~
 
       Commonmark Definition
 
@@ -55,7 +55,7 @@ class TestExtensions < Minitest::Test
     output = Commonmarker.to_html(markdown, options: options)
 
     html = <<~HTML
-      <p>~strikethrogh disabled to ensure options accepted~</p>
+      <p>~strikethrough disabled to ensure options accepted~</p>
       <dl><dt>Commonmark Definition</dt>
       <dd>
       <p>Ruby wrapper for comrak (CommonMark parser)</p>

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -40,4 +40,28 @@ class TestExtensions < Minitest::Test
       Commonmarker.to_html("<!--hello--> <blah> <xmp>\n", options: options),
     )
   end
+
+  def test_definition_lists
+    markdown = <<~MARKDOWN
+      ~strikethrogh disabled to ensure options accepted~
+
+      Commonmark Definition
+
+      : Ruby wrapper for comrak (CommonMark parser)
+    MARKDOWN
+
+    extensions = { strikethrough: false,  description_lists: true }
+    options = { extension: extensions, render: { hardbreaks: false } }
+    output = Commonmarker.to_html(markdown, options: options)
+
+    html = <<~HTML
+      <p>~strikethrogh disabled to ensure options accepted~</p>
+      <dl><dt>Commonmark Definition</dt>
+      <dd>
+      <p>Ruby wrapper for comrak (CommonMark parser)</p>
+      </dd>
+      </dl>
+    HTML
+    assert_equal(output, html)
+  end
 end

--- a/test/test_spec.rb
+++ b/test/test_spec.rb
@@ -10,7 +10,7 @@ class TestSpec < Minitest::Test
     define_method("test_to_html_example_#{testcase[:example]}") do
       opts = {
         render: {
-          unsafe_: true,
+          unsafe: true,
         },
         extension: testcase[:extensions].each_with_object({}) do |ext, hash|
           hash[ext] = true


### PR DESCRIPTION
Change of heart for https://github.com/gjtorikian/commonmarker/issues/219. Fine, `unsafe` instead of `unsafe_`.