### PR TITLE
fix front_matter_delimiter type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,11 @@ build/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# .ruby-version
-# .ruby-gemset
+# as rbenv
+.ruby-version
+.ruby-gemset
+# or ASDF-VM
+.tool-versions
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc

--- a/ext/commonmarker/src/options.rs
+++ b/ext/commonmarker/src/options.rs
@@ -104,7 +104,11 @@ fn iterate_extension_options(comrak_options: &mut ComrakOptions, options_hash: R
                     comrak_options.extension.description_lists = TryConvert::try_convert(value)?;
                 }
                 Ok(Cow::Borrowed(EXTENSION_FRONT_MATTER_DELIMITER)) => {
-                    comrak_options.extension.front_matter_delimiter = try_convert_string(value);
+                    if let Some(option) = try_convert_string(value) {
+                        if !option.is_empty() {
+                            comrak_options.extension.front_matter_delimiter = Some(option);
+                        }
+                    }
                 }
                 Ok(Cow::Borrowed(EXTENSION_SHORTCODES)) => {
                     comrak_options.extension.shortcodes = TryConvert::try_convert(value)?;

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -26,7 +26,7 @@ module Commonmarker
         header_ids: "",
         footnotes: false,
         description_lists: false,
-        front_matter_delimiter: nil,
+        front_matter_delimiter: "",
         shortcodes: true,
       },
       format: [:html].freeze,

--- a/lib/commonmarker/version.rb
+++ b/lib/commonmarker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Commonmarker
-  VERSION = "1.0.0.pre10"
+  VERSION = "1.0.0.pre11"
 end

--- a/test/frontmatter_test.rb
+++ b/test/frontmatter_test.rb
@@ -14,4 +14,13 @@ class TestFrontmatter < Minitest::Test
 
     assert_equal(expected, Commonmarker.to_html(md, plugins: nil))
   end
+
+  def test_frontmatter_custom_delimiter
+    md = "---\nyaml: true\nage: 42\n---\n# Title 1"
+    expected = <<~HTML
+      <h1>Title 1</h1>
+    HTML
+
+    assert_equal(expected, Commonmarker.to_html(md, options: { extension: { front_matter_delimiter: "---" } }))
+  end
 end


### PR DESCRIPTION
fix #256

With the fix, restores expected behavior

```ruby
require 'commonmarker'

Commonmarker.to_html("---\nyaml: true\nage: 42\n---\n# Title 1", options: { extension: { front_matter_delimiter: '---' } } )
# => "<h1>Title 1</h1>\n"
```

Note, the extension is still stripping anchors tho.

```ruby
Commonmarker.to_html("---\nyaml: true\nage: 42\n---\n# Title 1" )
# => "<hr />\n<h2><a href=\"#yaml-true-age-42\" aria-hidden=\"true\" class=\"anchor\" id=\"yaml-true-age-42\"></a>yaml: true<br />\nage: 42</h2>\n<h1><a href=\"#title-1\" aria-hidden=\"true\" class=\"anchor\" id=\"title-1\"></a>Title 1</h1>\n"
```