### PR TITLE
Add sourcepos option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Note that there is a distinction in comrak for "parse" options and "render" opti
 | `width`           | The wrap column when outputting CommonMark.                                                            | `80`    |
 | `unsafe`          | Allow rendering of raw HTML and potentially dangerous links.                                           | `false` |
 | `escape`          | Escape raw HTML instead of clobbering it.                                                              | `false` |
+| `sourcepos`       | Include source position attribute in HTML and XML output.                                              | `false` |
 
 As well, there are several extensions which you can toggle in the same manner:
 

--- a/ext/commonmarker/src/options.rs
+++ b/ext/commonmarker/src/options.rs
@@ -33,6 +33,7 @@ const RENDER_GITHUB_PRE_LANG: &str = "github_pre_lang";
 const RENDER_WIDTH: &str = "width";
 const RENDER_UNSAFE: &str = "unsafe";
 const RENDER_ESCAPE: &str = "escape";
+const RENDER_SOURCEPOS: &str = "sourcepos";
 
 fn iterate_render_options(comrak_options: &mut ComrakOptions, options_hash: RHash) {
     options_hash
@@ -52,6 +53,9 @@ fn iterate_render_options(comrak_options: &mut ComrakOptions, options_hash: RHas
                 }
                 Ok(Cow::Borrowed(RENDER_ESCAPE)) => {
                     comrak_options.render.escape = TryConvert::try_convert(value)?;
+                }
+                Ok(Cow::Borrowed(RENDER_SOURCEPOS)) => {
+                    comrak_options.render.sourcepos = TryConvert::try_convert(value)?;
                 }
                 _ => {}
             }

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -15,6 +15,7 @@ module Commonmarker
         width: 80,
         unsafe: false,
         escape: false,
+        sourcepos: false,
       }.freeze,
       extension: {
         strikethrough: true,

--- a/lib/commonmarker/version.rb
+++ b/lib/commonmarker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Commonmarker
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/test/sourcepos_test.rb
+++ b/test/sourcepos_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestSourcepos < Minitest::Test
+  def test_to_html
+    md = <<~MARKDOWN
+      # heading
+      paragraph
+
+      - list1
+    MARKDOWN
+    expected = <<~HTML
+      <h1 data-sourcepos="1:1-1:9"><a href="#heading" aria-hidden="true" class="anchor" id="heading"></a>heading</h1>
+      <p data-sourcepos="2:1-2:9">paragraph</p>
+      <ul data-sourcepos="4:1-4:7">
+      <li data-sourcepos="4:1-4:7">list1</li>
+      </ul>
+    HTML
+
+    assert_equal(expected, Commonmarker.to_html(md, options: { render: { sourcepos: true } }))
+  end
+end


### PR DESCRIPTION
This pull request fixes an issue introduced in `commonmarker` version 1.0.0, where the ability to specify the `sourcepos` option was unintentionally(?) removed. 

The goal is to restore the functionality of specifying `sourcepos`.