### PR TITLE
Expose code and code blocks' literals via string_content/=.

### DIFF
--- a/ext/commonmarker/src/node.rs
+++ b/ext/commonmarker/src/node.rs
@@ -669,6 +669,14 @@ impl CommonmarkerNode {
     fn get_string_content(&self) -> Result<String, magnus::Error> {
         let node = self.inner.borrow();
 
+        match node.data.value {
+            ComrakNodeValue::Code(ref code) => return Ok(code.literal.to_string()),
+            ComrakNodeValue::CodeBlock(ref code_block) => {
+                return Ok(code_block.literal.to_string())
+            }
+            _ => {}
+        }
+
         match node.data.value.text() {
             Some(s) => Ok(s.to_string()),
             None => Err(magnus::Error::new(
@@ -680,6 +688,18 @@ impl CommonmarkerNode {
 
     fn set_string_content(&self, new_content: String) -> Result<bool, magnus::Error> {
         let mut node = self.inner.borrow_mut();
+
+        match node.data.value {
+            ComrakNodeValue::Code(ref mut code) => {
+                code.literal = new_content;
+                return Ok(true);
+            }
+            ComrakNodeValue::CodeBlock(ref mut code_block) => {
+                code_block.literal = new_content;
+                return Ok(true);
+            }
+            _ => {}
+        }
 
         match node.data.value.text_mut() {
             Some(s) => {

--- a/lib/commonmarker/version.rb
+++ b/lib/commonmarker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Commonmarker
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -136,6 +136,7 @@ class NodeTest < Minitest::Test
 
     def test_code_inline_can_set_string_content
       @code_inline.string_content = "string content"
+
       assert_match(%r{<code>string content</code>}, @document.to_html)
     end
   end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -102,9 +102,10 @@ class NodeTest < Minitest::Test
 
   class StringContentTest < Minitest::Test
     def setup
-      @document = Commonmarker.parse("**HELLO!** \n***\n This has nodes!")
+      @document = Commonmarker.parse("**HELLO!** \n***\n This has `nodes`!")
       @paragraph = @document.first_child
       @emph = @paragraph.first_child
+      @code_inline = @document.last_child.last_child.previous_sibling
     end
 
     def test_node_can_get_string_content
@@ -127,6 +128,15 @@ class NodeTest < Minitest::Test
       end
 
       assert_match(%r{<strong>HELLO!</strong>}, @document.to_html)
+    end
+
+    def test_code_inline_can_get_string_content
+      assert_equal("nodes", @code_inline.string_content)
+    end
+
+    def test_code_inline_can_set_string_content
+      @code_inline.string_content = "string content"
+      assert_match(%r{<code>string content</code>}, @document.to_html)
     end
   end
 


### PR DESCRIPTION
Hiya! What do you think of this? Currently the `literal` members of Code and CodeBlock nodes isn't exposed anywhere.

The discrepancy between these and `text()`-fetchable things is a bit unfortunate on the Comrak side, but it's a side-effect of its legacy (i.e. the implication that `text()` means "get me the content of a Text node, and fail if it isn't one") — I see no reason to do the same to `string_content` just because of what it's backed by currently.

Fixes #289.