### PR TITLE
benchmark: correct Commonmarker::Node.to_html input.

### DIFF
--- a/test/benchmark.rb
+++ b/test/benchmark.rb
@@ -33,7 +33,7 @@ large = File.read("test/benchmark/large.md").freeze
     end
 
     x.report("Commonmarker::Node.to_html") do
-      Commonmarker.parse(large).to_html
+      Commonmarker.parse(input).to_html
     end
 
     x.report("Kramdown::Document#to_html") do


### PR DESCRIPTION
The benchmark test for `Commonmarker.parse` is hard-coded to the `large` input file. This change fixes the reference for the benchmark.