### PR TITLE
Readme defintion of `each` seems ot conflict with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can also modify the following attributes:
 You can use `walk` or `each` to iterate over nodes:
 
 - `walk` will iterate on a node and recursively iterate on a node's children.
-- `each` will iterate on a node and its children, but no further.
+- `each` will iterate on a node's direct children, but no further.
 
 ```ruby
 require 'commonmarker'


### PR DESCRIPTION
The readme mentions that Node#each will iterate on a node and its first-level children (implying self will be yielded), but from [the source file](https://github.com/gjtorikian/commonmarker/blob/55c3b03708b31f1af37a53b3312f91400594223d/lib/commonmarker/node.rb#L27) it seems that only the children are yielded.

Some basic testing seems to yield just the children for me, but feel free to correct me if I'm missing something here :)