### PR TITLE
[0.x] Fix memory leaks of string buffers

### DIFF
--- a/lib/commonmarker/version.rb
+++ b/lib/commonmarker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CommonMarker
-  VERSION = "0.23.10"
+  VERSION = "0.23.11"
 end


### PR DESCRIPTION
In a few places we were passing malloc'd memory to rb_str_new (and variants) and returning the resulting VALUE without freeing the passed C string buffer.

One of these leaks was introduced by https://github.com/gjtorikian/commonmarker/pull/171 (we can see that some calls to `free` were lost in the rewrite), but others seem to predate that.

After this change I'm able to run `ASAN_OPTIONS="detect_leaks=1" RUBY_FREE_AT_EXIT=1 bundle exec rake` with an ASAN-built Ruby without errors.

``` ruby
require "commonmarker"
10.times do
  100.times do
    CommonMarker.render_html("hello, world\n"*10000)
  end
  puts `ps -orss= -p #$$`
end
```

```

❯ bundle exec ruby test.rb
74736
112112
112112
128496
172016
203120
203120
203120
241392
266480
```

cc @anticomputer @phillmv 