### PR TITLE
Fixed the issue where nil for header_ids 

### DIFF
--- a/lib/commonmarker.rb
+++ b/lib/commonmarker.rb
@@ -21,7 +21,7 @@ module Commonmarker
       raise TypeError, "text must be UTF-8 encoded; got #{text.encoding}!" unless text.encoding.name == "UTF-8"
       raise TypeError, "options must be a Hash; got a #{options.class}!" unless options.is_a?(Hash)
 
-      opts = Config.process_options(options)
+      opts = Config.process_options(options.deep_dup)
 
       commonmark_parse(text, options: opts)
     end
@@ -38,7 +38,7 @@ module Commonmarker
       raise TypeError, "text must be UTF-8 encoded; got #{text.encoding}!" unless text.encoding.name == "UTF-8"
       raise TypeError, "options must be a Hash; got a #{options.class}!" unless options.is_a?(Hash)
 
-      opts = Config.process_options(options)
+      opts = Config.process_options(options.deep_dup)
       plugins = Config.process_plugins(plugins)
 
       commonmark_to_html(text, options: opts, plugins: plugins)

--- a/lib/commonmarker/node.rb
+++ b/lib/commonmarker/node.rb
@@ -41,7 +41,7 @@ module Commonmarker
     def to_html(options: Commonmarker::Config::OPTIONS, plugins: Commonmarker::Config::PLUGINS)
       raise TypeError, "options must be a Hash; got a #{options.class}!" unless options.is_a?(Hash)
 
-      opts = Config.process_options(options)
+      opts = Config.process_options(options.deep_dup)
       plugins = Config.process_plugins(plugins)
 
       node_to_html(options: opts, plugins: plugins).force_encoding("utf-8")
@@ -56,7 +56,7 @@ module Commonmarker
     def to_commonmark(options: Commonmarker::Config::OPTIONS, plugins: Commonmarker::Config::PLUGINS)
       raise TypeError, "options must be a Hash; got a #{options.class}!" unless options.is_a?(Hash)
 
-      opts = Config.process_options(options)
+      opts = Config.process_options(options.deep_dup)
       plugins = Config.process_plugins(plugins)
 
       node_to_commonmark(options: opts, plugins: plugins).force_encoding("utf-8")

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -45,4 +45,39 @@ class ConfigTest < Minitest::Test
     # hardbreaks still work
     assert_equal("<p>aaaa<br />\nbbbb</p>\n", Commonmarker.to_html("aaaa\nbbbb", options: { render: { unsafe: false } }))
   end
+
+  def test_same_config_again
+    user_config = {
+      extension: {
+        header_ids: nil,
+      },
+    }
+
+    text = "# Heading-1"
+    expected = "<h1>Heading-1</h1>\n"
+
+    assert_equal(expected, Commonmarker.to_html(text, options: user_config))
+
+    # expect same result
+    assert_equal(expected, Commonmarker.to_html(text, options: user_config))
+  end
+
+  def test_render_and_to_html_with_same_config
+    user_config = {
+      extension: {
+        header_ids: nil,
+      },
+    }
+
+    text = "# Heading-1"
+    expected = "<h1>Heading-1</h1>\n"
+
+    doc = Commonmarker.parse(text, options: user_config)
+    # doc.walk do |node|
+    #   # do something
+    # end
+    doc.to_html(options: user_config)
+
+    assert_equal(expected, Commonmarker.to_html(text, options: user_config))
+  end
 end


### PR DESCRIPTION
## Summary

I have fixed the issue where specifying `nil` for `:header_ids` in the `:extension` config would result in the `nil` option being cleared when reusing the config.

## Target Version

https://github.com/gjtorikian/commonmarker/tree/v2.0.0/ext/commonmarker

## Use Case

```ruby
user_config = {
  extension: {
    header_ids: nil,
  },
}

text = "# Heading-1"

doc = Commonmarker.parse(text, options: user_config) # In this process, header_ids is nil, so it gets removed. 
doc.walk do |node|
  # do something
end

puts doc.to_html(options: user_config)
```

### Expected Output

`<h1>Heading-1</h1>`

### Actual Output in

`<h1><a href=\"#heading-1\" aria-hidden=\"true\" class=\"anchor\" id=\"heading-1\"></a>Heading-1</h1>`
