### PR TITLE
Support Raw Node

### DIFF
--- a/ext/commonmarker/src/node.rs
+++ b/ext/commonmarker/src/node.rs
@@ -473,6 +473,18 @@ impl CommonmarkerNode {
                 ComrakNodeValue::WikiLink(NodeWikiLink { url })
             }
 
+            "raw" => {
+                let kwargs = scan_args::get_kwargs::<_, (), (Option<String>,), ()>(
+                    args.keywords,
+                    &[],
+                    &["content"],
+                )?;
+
+                let (content,) = kwargs.optional;
+
+                ComrakNodeValue::Raw(content.unwrap_or_default())
+            }
+
             _ => panic!("unknown node type {}", node_type),
         };
 

--- a/test/node/creation_test.rb
+++ b/test/node/creation_test.rb
@@ -45,6 +45,7 @@ class NodeCreationTest < Minitest::Test
       [:multiline_block_quote, fence_length: 2, fence_offset: 0],
       [:escaped],
       [:wikilink, url: "www.yetto.app/billy.png"],
+      [:raw],
     ]
     node_types.each do |type, arguments|
       node = arguments.nil? ? Commonmarker::Node.new(type) : Commonmarker::Node.new(type, **arguments)


### PR DESCRIPTION
To address the requirements mentioned in https://github.com/kivikakk/comrak/discussions/477, [Raw Node has been added to Comrak](https://github.com/kivikakk/comrak/pull/511).

This PR supports the Raw Node in Commonmarker.