### PR TITLE
Adds tasklist_classes to the list of render options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Note that there is a distinction in comrak for "parse" options and "render" opti
 | `ignore_empty_links` | Ignores empty links, leaving the Markdown text in place.                                               | `false` |
 | `gfm_quirks`         | Outputs HTML with GFM-style quirks; namely, not nesting `<strong>` inlines.                            | `false` |
 | `prefer_fenced`      | Always output fenced code blocks, even where an indented one could be used.                            | `false` |
+| `tasklist_classes`   | Add CSS classes to the HTML output of the tasklist extension                                           | `false` |
 
 As well, there are several extensions which you can toggle in the same manner:
 

--- a/ext/commonmarker/src/options.rs
+++ b/ext/commonmarker/src/options.rs
@@ -49,6 +49,7 @@ const RENDER_IGNORE_SETEXT: &str = "ignore_setext";
 const RENDER_IGNORE_EMPTY_LINKS: &str = "ignore_empty_links";
 const RENDER_GFM_QUIRKS: &str = "gfm_quirks";
 const RENDER_PREFER_FENCED: &str = "prefer_fenced";
+const RENDER_TASKLIST_CLASSES: &str = "tasklist_classes";
 
 fn iterate_render_options(comrak_options: &mut ComrakOptions, options_hash: RHash) {
     options_hash
@@ -89,6 +90,9 @@ fn iterate_render_options(comrak_options: &mut ComrakOptions, options_hash: RHas
                 }
                 Ok(Cow::Borrowed(RENDER_PREFER_FENCED)) => {
                     comrak_options.render.prefer_fenced = TryConvert::try_convert(value)?;
+                }
+                Ok(Cow::Borrowed(RENDER_TASKLIST_CLASSES)) => {
+                    comrak_options.render.tasklist_classes = TryConvert::try_convert(value)?;
                 }
                 _ => {}
             }

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -24,6 +24,7 @@ module Commonmarker
         ignore_empty_links: false,
         gfm_quirks: false,
         prefer_fenced: false,
+        tasklist_classes: false,
       }.freeze,
       extension: {
         strikethrough: true,

--- a/test/tasklists_test.rb
+++ b/test/tasklists_test.rb
@@ -18,4 +18,20 @@ class TasklistsTest < Minitest::Test
 
     assert_equal(expected, html)
   end
+
+  def test_to_html_with_tasklist_classes
+    text = <<-MD
+ - [x] Add task list
+ - [ ] Define task list
+    MD
+    html = Commonmarker.to_html(text, options: { extension: { tasklist: true }, render: { tasklist_classes: true } })
+    expected = <<~HTML
+      <ul class="contains-task-list">
+      <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" checked="" disabled="" /> Add task list</li>
+      <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled="" /> Define task list</li>
+      </ul>
+    HTML
+
+    assert_equal(expected, html)
+  end
 end


### PR DESCRIPTION
Fixes #364.

By enabling the `tasklist_classes` in render_options you can easily style the HTML generated by the tasklist extension.