### PR TITLE
Support Ruby 4 in the `cmark` version

### DIFF
--- a/commonmarker.gemspec
+++ b/commonmarker.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.executables = ["commonmarker"]
   s.require_paths = ["lib", "ext"]
-  s.required_ruby_version = [">= 2.6", "< 4.0"]
+  s.required_ruby_version = [">= 2.6", "< 5.0"]
 
   s.metadata["rubygems_mfa_required"] = "true"
 


### PR DESCRIPTION
I’m still using the `cmark` version (which is hopefully still being maintained 😅), but that version’s gemspec remains locked to `< 4.0`. I believe we can just bump that to `< 5.0` and that the gem will work on Ruby 4 as is, though I’m still testing that out a bit. I’ve tried to update my application to the new comrak wrapper but I’ve been reliant on the ability to use [a custom `CommonMarker::HTMLRenderer` subclass](https://github.com/davidcelis/davidcel.is/blob/main/app/lib/markdown/renderer.rb#L8) that adds attributes to link nodes beyond the standard `href` and `title` attributes. Either custom renderers aren’t possible in the comrak version or I haven’t been able to figure out how to port this custom logic over based on available documentation (I’m happy to open a separate issue about this as well)