### PR TITLE
Fix typo in Cargo.toml comment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 # This Cargo.toml is here to let externals tools (IDEs, etc.) know that this is
-# a Rust project. Your extensions depedencies should be added to the Cargo.toml
+# a Rust project. Your extensions dependencies should be added to the Cargo.toml
 # in the ext/ directory.
 
 [workspace]


### PR DESCRIPTION
Fix a spelling error in the root `Cargo.toml` comment:

`depedencies` → `dependencies`