### PR TITLE
fix: re-release 2.8.1 due to publishing error

### DIFF
--- a/lib/commonmarker/version.rb
+++ b/lib/commonmarker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Commonmarker
-  VERSION = "2.8.0"
+  VERSION = "2.8.1"
 end


### PR DESCRIPTION
According to https://github.com/rubygems/rubygems.org/issues/6099, sometimes, pushing multiple versions of a gem causes it to fail, sometimes.

This release is going out to close #455 by switching to [serialized uploads of the gem](https://github.com/gjtorikian/actions/commit/6ea0223c8e3fcb53521562c0e785bd854cab7f35).