### PR TITLE
Add alert_type accessors for alert nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can also modify the following attributes:
 - `list_start`
 - `list_tight`
 - `fence_info`
+- `alert_type`
 
 #### Example: Walking the AST
 

--- a/ext/commonmarker/src/node.rs
+++ b/ext/commonmarker/src/node.rs
@@ -522,10 +522,11 @@ impl CommonmarkerNode {
                     "tip" => AlertType::Tip,
                     "important" => AlertType::Important,
                     "warning" => AlertType::Warning,
+                    "caution" => AlertType::Caution,
                     _ => {
                         return Err(magnus::Error::new(
                             ruby.exception_arg_error(),
-                            "alert type must be `note`, `tip`, `important`, or `warning`",
+                            "alert type must be `note`, `tip`, `important`, `warning`, or `caution`",
                         ));
                     }
                 };
@@ -980,6 +981,50 @@ impl CommonmarkerNode {
         }
     }
 
+    fn get_alert_type(ruby: &Ruby, rb_self: &Self) -> Result<Symbol, magnus::Error> {
+        let node = rb_self.inner.borrow();
+
+        match &node.data.value {
+            ComrakNodeValue::Alert(alert) => match alert.alert_type {
+                AlertType::Note => Ok(ruby.to_symbol("note")),
+                AlertType::Tip => Ok(ruby.to_symbol("tip")),
+                AlertType::Important => Ok(ruby.to_symbol("important")),
+                AlertType::Warning => Ok(ruby.to_symbol("warning")),
+                AlertType::Caution => Ok(ruby.to_symbol("caution")),
+            },
+            _ => Err(magnus::Error::new(
+                ruby.exception_type_error(),
+                "node is not an alert node",
+            )),
+        }
+    }
+
+    fn set_alert_type(
+        ruby: &Ruby,
+        rb_self: &Self,
+        new_type: Symbol,
+    ) -> Result<bool, magnus::Error> {
+        let mut node = rb_self.inner.borrow_mut();
+
+        match node.data.value {
+            ComrakNodeValue::Alert(ref mut alert) => {
+                match new_type.to_string().as_str() {
+                    "note" => alert.alert_type = AlertType::Note,
+                    "tip" => alert.alert_type = AlertType::Tip,
+                    "important" => alert.alert_type = AlertType::Important,
+                    "warning" => alert.alert_type = AlertType::Warning,
+                    "caution" => alert.alert_type = AlertType::Caution,
+                    _ => return Ok(false),
+                }
+                Ok(true)
+            }
+            _ => Err(magnus::Error::new(
+                ruby.exception_type_error(),
+                "node is not an alert node",
+            )),
+        }
+    }
+
     fn to_html(ruby: &Ruby, rb_self: &Self, args: &[Value]) -> Result<String, magnus::Error> {
         let args = scan_args::scan_args::<(), (), (), (), _, ()>(args)?;
 
@@ -1258,6 +1303,8 @@ pub fn init(ruby: &Ruby, m_commonmarker: RModule) -> Result<(), magnus::Error> {
     c_node.define_method("fenced=", method!(CommonmarkerNode::set_fenced, 1))?;
     c_node.define_method("fence_info", method!(CommonmarkerNode::get_fence_info, 0))?;
     c_node.define_method("fence_info=", method!(CommonmarkerNode::set_fence_info, 1))?;
+    c_node.define_method("alert_type", method!(CommonmarkerNode::get_alert_type, 0))?;
+    c_node.define_method("alert_type=", method!(CommonmarkerNode::set_alert_type, 1))?;
 
     Ok(())
 }

--- a/lib/commonmarker/node/inspect.rb
+++ b/lib/commonmarker/node/inspect.rb
@@ -26,6 +26,7 @@ module Commonmarker
             :list_start,
             :list_tight,
             :fence_info,
+            :alert_type,
           ].filter_map do |name|
             [name, __send__(name)]
           rescue StandardError

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -333,4 +333,47 @@ class NodeTest < Minitest::Test
       assert_match(/<pre lang=\"perl\"/, @document.to_html)
     end
   end
+
+  class AlertTypeTest < Minitest::Test
+    def test_has_alert_type_for_parsed_alerts
+      [:note, :tip, :important, :warning, :caution].each do |type|
+        document = Commonmarker.parse("> [!#{type.upcase}]\n> Content", options: { extension: { alerts: true } })
+
+        assert_equal(type, document.first_child.alert_type)
+      end
+    end
+
+    def test_has_alert_type_for_created_alerts
+      [:note, :tip, :important, :warning, :caution].each do |type|
+        node = Commonmarker::Node.new(:alert, type: type)
+
+        assert_equal(type, node.alert_type)
+      end
+    end
+
+    def test_can_set_alert_type
+      node = Commonmarker::Node.new(:alert, type: :note)
+
+      node.alert_type = :warning
+
+      assert_equal(:warning, node.alert_type)
+      assert_match(/markdown-alert-warning/, node.to_html)
+    end
+
+    def test_can_prevent_a_malicious_alert_type
+      node = Commonmarker::Node.new(:alert, type: :note)
+
+      node.alert_type = :oopsies
+
+      assert_equal(:note, node.alert_type)
+    end
+
+    def test_non_alert_raises
+      document = Commonmarker.parse("hello")
+      paragraph = document.first_child
+
+      assert_raises(TypeError) { paragraph.alert_type }
+      assert_raises(TypeError) { paragraph.alert_type = :note }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Add `Commonmarker::Node#alert_type` and `Commonmarker::Node#alert_type=` for alert nodes.
- Return and accept `:note`, `:tip`, `:important`, `:warning`, and `:caution`.
- Include `:caution` in `Node.new(:alert, type: ...)` to match comrak `AlertType` variants.
- Show `alert_type` in node inspection and document it in the README.

## Motivation

Alert nodes store their type in the comrak `NodeAlert.alert_type` field, but commonmarker does not currently expose that field through the Ruby API.

That means applications walking the AST cannot tell whether an alert node is a note, tip, important, warning, or caution alert without rendering the node to HTML and parsing the generated CSS class. Exposing `alert_type` makes that information available directly from the AST node.

## Test plan

- `bundle exec rake compile`
- `bundle exec rake test`
- `bundle exec rubocop`