### PR TITLE
feat: Upgrade to comrak 0.54 with math_latex + alert_style options, and changed header_ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9795cb30f4deefbf33488819707e0f9630535dd56208ec273c1b3f150196377a"
+checksum = "0d5910408554659ed848ff469e67ec83b30f179e72cec286cfdae64d1616f466"
 dependencies = [
  "caseless",
  "emojis",
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minimal-lexical"
@@ -442,9 +442,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -533,9 +533,9 @@ checksum = "e03e7866abec1101869ffa8e2c8355c4c2419d0214ece0cc3e428e5b94dea6e9"
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -545,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -562,9 +562,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "same-file"
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note that there is a distinction in comrak for "parse" options and "render" opti
 | `prefer_fenced`      | Always output fenced code blocks, even where an indented one could be used.                            | `false` |
 | `tasklist_classes`   | Add CSS classes to the HTML output of the tasklist extension                                           | `false` |
 | `compact_html`       | Suppress newlines in pretty-printed HTML output.                                                       | `false` |
+| `alert_style`        | The style of alert output: `"specific"` (`<div class="markdown-alert">`) or `"semantic"` (`<aside class="admonition">`). | `"specific"` |
 
 As well, there are several extensions which you can toggle in the same manner:
 
@@ -212,6 +213,7 @@ Commonmarker.to_html('"Hi *there*"', options: {
 | `front_matter_delimiter`      | Enables the front matter extension.                                                                                 | `""`    |
 | `multiline_block_quotes`      | Enables the multiline block quotes extension.                                                                       | `false` |
 | `math_dollars`, `math_code`   | Enables the math extension.                                                                                         | `false` |
+| `math_latex`                  | Enables the math extension with LaTeX-style delimiters (`\(inline\)`, `\[display\]`).                               | `false` |
 | `shortcodes`                  | Enables the shortcodes extension.                                                                                   | `true`  |
 | `wikilinks_title_before_pipe` | Enables the wikilinks extension, placing the title before the dividing pipe.                                        | `false` |
 | `wikilinks_title_after_pipe`  | Enables the wikilinks extension, placing the title after the dividing pipe.                                         | `false` |

--- a/ext/commonmarker/Cargo.toml
+++ b/ext/commonmarker/Cargo.toml
@@ -21,7 +21,7 @@ syntect = { version = "5.3", default-features = false, features = [
 
 # Everywhere except Windows: Oniguruma, the faster engine.
 [target.'cfg(not(windows))'.dependencies]
-comrak = { version = "0.53", default-features = false, features = [
+comrak = { version = "0.54", default-features = false, features = [
     "shortcodes",
     "syntect-onig",
 ] }
@@ -30,7 +30,7 @@ comrak = { version = "0.53", default-features = false, features = [
 # linking a second copy (onig_sys) collides at link time and segfaults (xref #467).
 # syntect-fancy swaps in the pure-Rust fancy-regex backend instead.
 [target.'cfg(windows)'.dependencies]
-comrak = { version = "0.53", default-features = false, features = [
+comrak = { version = "0.54", default-features = false, features = [
     "shortcodes",
     "syntect-fancy",
 ] }

--- a/ext/commonmarker/src/options.rs
+++ b/ext/commonmarker/src/options.rs
@@ -58,6 +58,7 @@ const RENDER_GFM_QUIRKS: &str = "gfm_quirks";
 const RENDER_PREFER_FENCED: &str = "prefer_fenced";
 const RENDER_TASKLIST_CLASSES: &str = "tasklist_classes";
 const RENDER_COMPACT_HTML: &str = "compact_html";
+const RENDER_ALERT_STYLE: &str = "alert_style";
 
 pub fn iterate_render_options(comrak_options: &mut comrak::options::Render, options_hash: RHash) {
     options_hash
@@ -102,6 +103,12 @@ pub fn iterate_render_options(comrak_options: &mut comrak::options::Render, opti
                 Cow::Borrowed(RENDER_COMPACT_HTML) => {
                     comrak_options.compact_html = TryConvert::try_convert(value)?;
                 }
+                Cow::Borrowed(RENDER_ALERT_STYLE) => {
+                    comrak_options.alert_style = match try_convert_string(value).as_deref() {
+                        Some("semantic") => comrak::options::AlertStyleType::Semantic,
+                        _ => comrak::options::AlertStyleType::Specific,
+                    };
+                }
                 _ => {}
             }
             Ok(ForEach::Continue)
@@ -124,6 +131,7 @@ const EXTENSION_FRONT_MATTER_DELIMITER: &str = "front_matter_delimiter";
 const EXTENSION_MULTILINE_BLOCK_QUOTES: &str = "multiline_block_quotes";
 const EXTENSION_MATH_DOLLARS: &str = "math_dollars";
 const EXTENSION_MATH_CODE: &str = "math_code";
+const EXTENSION_MATH_LATEX: &str = "math_latex";
 const EXTENSION_SHORTCODES: &str = "shortcodes";
 const EXTENSION_WIKILINKS_TITLE_AFTER_PIPE: &str = "wikilinks_title_after_pipe";
 const EXTENSION_WIKILINKS_TITLE_BEFORE_PIPE: &str = "wikilinks_title_before_pipe";
@@ -193,6 +201,9 @@ pub fn iterate_extension_options(
                 }
                 Cow::Borrowed(EXTENSION_MATH_CODE) => {
                     comrak_options.math_code = TryConvert::try_convert(value)?;
+                }
+                Cow::Borrowed(EXTENSION_MATH_LATEX) => {
+                    comrak_options.math_latex = TryConvert::try_convert(value)?;
                 }
                 Cow::Borrowed(EXTENSION_SHORTCODES) => {
                     comrak_options.shortcodes = TryConvert::try_convert(value)?;

--- a/lib/commonmarker/config.rb
+++ b/lib/commonmarker/config.rb
@@ -28,6 +28,7 @@ module Commonmarker
         prefer_fenced: false,
         tasklist_classes: false,
         compact_html: false,
+        alert_style: "specific",
       }.freeze,
       extension: {
         strikethrough: true,
@@ -45,6 +46,7 @@ module Commonmarker
         multiline_block_quotes: false,
         math_dollars: false,
         math_code: false,
+        math_latex: false,
         shortcodes: true,
         wikilinks_title_before_pipe: false,
         wikilinks_title_after_pipe: false,

--- a/test/alert_test.rb
+++ b/test/alert_test.rb
@@ -49,6 +49,21 @@ class FrontmatterTest < Minitest::Test
     assert_equal(expected, Commonmarker.to_html(md, options: { extension: { alerts: true } }))
   end
 
+  def test_renders_alert_with_semantic_style
+    md = "> [!note]\n> Something of note"
+
+    expected = <<~HTML
+      <aside class="admonition note">
+      <p class="admonition-title">Note</p>
+      <p>Something of note</p>
+      </aside>
+    HTML
+
+    options = { extension: { alerts: true }, render: { alert_style: "semantic" } }
+
+    assert_equal(expected, Commonmarker.to_html(md, options: options))
+  end
+
   def test_renders_a_complicated_node
     node = Commonmarker::Node.new(:alert, type: :warning, title: "This is bad")
 

--- a/test/math_test.rb
+++ b/test/math_test.rb
@@ -24,4 +24,15 @@ class MathTest < Minitest::Test
 
     assert_equal(expected, Commonmarker.to_html(md, options: { extension: { math_code: true } }))
   end
+
+  def test_math_latex_to_html
+    md = <<~MARKDOWN
+      \\(1 + 2\\) and \\[x = y\\]
+    MARKDOWN
+    expected = <<~HTML
+      <p><span data-math-style="inline">1 + 2</span> and <span data-math-style="display">x = y</span></p>
+    HTML
+
+    assert_equal(expected, Commonmarker.to_html(md, options: { extension: { math_latex: true } }))
+  end
 end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -208,7 +208,7 @@ class NodeTest < Minitest::Test
       @header_node.header_level = 6
 
       assert_equal(6, @header_node.header_level)
-      assert_match(%r{<h6><a href=\"#header-three\" aria-hidden=\"true\" class=\"anchor\" id=\"header-three\"></a>Header Three</h6>\n}, @document.to_html)
+      assert_match(%r{<h6 id=\"header-three\">Header Three<a href=\"#header-three\" aria-label=\"Link to heading 'Header Three'\" data-heading-content=\"Header Three\" class=\"anchor\"></a></h6>\n}, @document.to_html)
     end
   end
 

--- a/test/sourcepos_test.rb
+++ b/test/sourcepos_test.rb
@@ -11,7 +11,7 @@ class SourceposTest < Minitest::Test
       - list1
     MARKDOWN
     expected = <<~HTML
-      <h1 data-sourcepos="1:1-1:9"><a href="#heading" aria-hidden="true" class="anchor" id="heading"></a>heading</h1>
+      <h1 id="heading" data-sourcepos="1:1-1:9">heading<a href="#heading" aria-label="Link to heading 'heading'" data-heading-content="heading" class="anchor"></a></h1>
       <p data-sourcepos="2:1-2:9">paragraph</p>
       <ul data-sourcepos="4:1-4:7">
       <li data-sourcepos="4:1-4:7">list1</li>


### PR DESCRIPTION
## Summary
- Bumps comrak from 0.53 to 0.54, picking up upstream fixes for CommonMark roundtripping with whitespace entities and a crash with ordered lists nested in blockquotes.
- Exposes the new `math_latex` extension option: `\(...\)` and `\[...\]` delimiters render as inline/display math spans.
- Exposes the new `alert_style` render option: `"semantic"` outputs `<aside class="admonition">` (matching docutils) instead of the default `markdown-alert` divs.
- ⚠️ Heading anchor markup changed upstream: the `id` now lives on the heading element and the anchor moved to the end with `aria-label` + `data-heading-content`, replacing the leading `aria-hidden` link. CSS/JS targeting the old markup will be affected — this warrants a minor version bump (2.9.0) and a prominent changelog entry.
